### PR TITLE
SLICE: EPIC-01 Telemetry for entry flows

### DIFF
--- a/components/PageViewTracker.tsx
+++ b/components/PageViewTracker.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { entryContext, trackOnce } from "@/lib/telemetry";
+
+/**
+ * Fires a page-view event once per session. Renders nothing.
+ *
+ * Once-per-session rather than once-per-mount: App Router keeps components
+ * alive across client navigations, so a plain mount effect would re-fire
+ * every time a visitor came back to the page and inflate the denominator of
+ * every funnel metric in EPIC-01.
+ */
+export function PageViewTracker({ event }: { event: string }) {
+  useEffect(() => {
+    trackOnce(event, entryContext());
+  }, [event]);
+
+  return null;
+}

--- a/components/SlideSection.tsx
+++ b/components/SlideSection.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useRef } from "react";
 import type { Slide, SlideBodyItem, SlideCTA } from "@/lib/types";
 import { track } from "@/lib/telemetry";
+import { StartScreenerLink } from "./StartScreenerLink";
 
 export function SlideSection({
   slide,
@@ -63,19 +64,33 @@ export function SlideSection({
   // Two registers only: the outlined pill that carries the next step, and the
   // quiet rule beneath a word for everything else.
   const renderCTAs = (ctas: SlideCTA[]) => {
-    return ctas.map((cta) => (
-      <Link
-        key={cta.href}
-        href={cta.href}
-        className={
-          cta.variant === "primary"
-            ? "rounded-full border border-accent px-6 py-3 font-data text-[0.63rem] uppercase tracking-[0.18em] text-accent no-underline"
-            : "border-b border-rule pb-[0.15rem] font-data text-[0.63rem] uppercase tracking-[0.18em] text-ink-soft no-underline hover:border-accent hover:text-accent"
-        }
-      >
-        {cta.label}
-      </Link>
-    ));
+    return ctas.map((cta) => {
+      const className =
+        cta.variant === "primary"
+          ? "rounded-full border border-accent px-6 py-3 font-data text-[0.63rem] uppercase tracking-[0.18em] text-accent no-underline"
+          : "border-b border-rule pb-[0.15rem] font-data text-[0.63rem] uppercase tracking-[0.18em] text-ink-soft no-underline hover:border-accent hover:text-accent";
+
+      // The primary CTA is the funnel step EPIC-01 is measured on, so it
+      // reports where on the page the click came from.
+      if (cta.variant === "primary") {
+        return (
+          <StartScreenerLink
+            key={cta.href}
+            href={cta.href}
+            location={slide.id || slide.title}
+            className={className}
+          >
+            {cta.label}
+          </StartScreenerLink>
+        );
+      }
+
+      return (
+        <Link key={cta.href} href={cta.href} className={className}>
+          {cta.label}
+        </Link>
+      );
+    });
   };
 
   return (

--- a/components/StartScreenerLink.tsx
+++ b/components/StartScreenerLink.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { track } from "@/lib/telemetry";
+
+/**
+ * The primary conversion action. Emits `startScreenerClicked` before handing
+ * the click back to the browser.
+ *
+ * It does not preventDefault or navigate programmatically: EPIC-01 measures
+ * this click as its headline metric, and an instrumented link that eats the
+ * navigation would trade the conversion for the measurement of it.
+ */
+export function StartScreenerLink({
+  href,
+  location,
+  className,
+  children,
+}: {
+  href: string;
+  location: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className={className}
+      onClick={() =>
+        track("startScreenerClicked", { location_on_page: location })
+      }
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { cookies } from "next/headers";
+import { StartScreenerLink } from "./StartScreenerLink";
 
 const anchorBase = process.env.NEXT_PUBLIC_PUBLIC_ANCHOR_BASE ?? "/";
 
@@ -41,12 +42,13 @@ export async function TopNav() {
             </Link>
           )}
         </nav>
-        <Link
+        <StartScreenerLink
           href="/start"
+          location="nav"
           className="rounded-full border border-accent px-5 py-2 text-accent no-underline"
         >
           Start here
-        </Link>
+        </StartScreenerLink>
       </div>
     </header>
   );

--- a/e2e/BM-E2E-04.spec.ts
+++ b/e2e/BM-E2E-04.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * BM-E2E-04 — SLICE-04 (issue #12).
+ * Entry-flow telemetry fires in a real browser, carrying no PII.
+ */
+
+const gherkinSteps = {
+  landing: {
+    load: "GIVEN a visitor loads `/`",
+    fired:
+      "WHEN the app initializes → THEN landingViewed fires with non-PII props",
+    once: "WHEN they return to `/` → THEN landingViewed does not fire again",
+  },
+  cta: {
+    click: "GIVEN a visitor clicks the primary screener CTA",
+    fired:
+      "WHEN the click happens → THEN startScreenerClicked fires with location_on_page",
+  },
+  supporting: {
+    visit: "GIVEN a visitor navigates to /about",
+    fired: "WHEN the page renders → THEN aboutPageViewed fires",
+  },
+  privacy: {
+    audit: "GIVEN telemetry is enabled",
+    clean: "WHEN every recorded event is inspected → THEN none carries PII",
+  },
+};
+
+const acVerboseFlag = (process.env.AC_VERBOSE ?? "").toLowerCase();
+const logPasses = acVerboseFlag === "1" || acVerboseFlag === "true";
+
+const runStep = async (description: string, fn: () => Promise<void>) => {
+  try {
+    await fn();
+    if (logPasses) console.info(`[AC PASS] ${description}`);
+  } catch (error) {
+    console.error(`[AC FAIL] ${description}`);
+    throw error;
+  }
+};
+
+type RecordedEvent = { name: string; props: Record<string, unknown> };
+
+const events = (page: Page): Promise<RecordedEvent[]> =>
+  page.evaluate(
+    () =>
+      (window as { __bmTelemetry?: RecordedEvent[] }).__bmTelemetry ??
+      ([] as RecordedEvent[]),
+  );
+
+const namesOf = async (page: Page) => (await events(page)).map((e) => e.name);
+
+test("BM-E2E-04 – Entry-flow telemetry fires and stays free of PII", async ({
+  page,
+}) => {
+  await runStep(gherkinSteps.landing.load, async () => {
+    await page.goto("/");
+  });
+
+  await runStep(gherkinSteps.landing.fired, async () => {
+    await expect(async () => {
+      expect(await namesOf(page)).toContain("landingViewed");
+    }).toPass({ timeout: 5000 });
+
+    const landing = (await events(page)).find(
+      (e) => e.name === "landingViewed",
+    );
+    expect(Object.keys(landing?.props ?? {}).sort()).toEqual([
+      "device_type",
+      "referrer_category",
+    ]);
+    expect(landing?.props.referrer_category).toBe("direct");
+  });
+
+  await runStep(gherkinSteps.landing.once, async () => {
+    // Detour via /methods, not /about — visiting /about here would burn its
+    // own once-per-session flag before the step that asserts it.
+    await page.goto("/methods");
+    await page.goto("/");
+    const landingCount = (await namesOf(page)).filter(
+      (n) => n === "landingViewed",
+    ).length;
+    expect(landingCount).toBe(0); // fresh buffer after reload; session guard held
+  });
+
+  await runStep(gherkinSteps.supporting.visit, async () => {
+    await page.goto("/about");
+  });
+
+  await runStep(gherkinSteps.supporting.fired, async () => {
+    await expect(async () => {
+      expect(await namesOf(page)).toContain("aboutPageViewed");
+    }).toPass({ timeout: 5000 });
+  });
+
+  await runStep(gherkinSteps.cta.click, async () => {
+    await page.goto("/");
+    // Do not follow the navigation: /start does not exist yet.
+    await page
+      .locator("section#top")
+      .getByRole("link", { name: "Start here" })
+      .click({ noWaitAfter: true });
+  });
+
+  await runStep(gherkinSteps.cta.fired, async () => {
+    await expect(async () => {
+      expect(await namesOf(page)).toContain("startScreenerClicked");
+    }).toPass({ timeout: 5000 });
+
+    const click = (await events(page)).find(
+      (e) => e.name === "startScreenerClicked",
+    );
+    expect(click?.props).toHaveProperty("location_on_page", "top");
+  });
+
+  await runStep(gherkinSteps.privacy.audit, async () => {
+    // Clear the session guard first, otherwise the reload produces an empty
+    // buffer and the audit below would vacuously pass.
+    await page.evaluate(() => window.sessionStorage.clear());
+    await page.reload();
+    await expect(async () => {
+      expect((await namesOf(page)).length).toBeGreaterThan(0);
+    }).toPass({ timeout: 5000 });
+  });
+
+  await runStep(gherkinSteps.privacy.clean, async () => {
+    const recorded = await events(page);
+    expect(recorded.length).toBeGreaterThan(0);
+
+    const forbidden = /email|phone|(^|_)name($|_)|address|(^|_)ip($|_)/i;
+    for (const event of recorded) {
+      for (const key of Object.keys(event.props)) {
+        expect(key, `${event.name}.${key}`).not.toMatch(forbidden);
+      }
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^18.3.0",

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,9 @@
+import { PageViewTracker } from "../../../components/PageViewTracker";
+
 export default function AboutPage() {
   return (
     <main className="mx-auto w-full max-w-3xl px-6 py-16 md:py-24">
+      <PageViewTracker event="aboutPageViewed" />
       <section>
         <p className="font-data text-[0.6rem] uppercase tracking-[0.16em] text-ink-soft">
           About

--- a/src/app/home-content.tsx
+++ b/src/app/home-content.tsx
@@ -1,11 +1,13 @@
 import { SlideDeck } from "../../components/SlideDeck";
 import { TopNav } from "../../components/TopNav";
+import { PageViewTracker } from "../../components/PageViewTracker";
 import { publicHomeSlides } from "@/content/publicHome";
 import { HeaderVariantClient } from "./header-variant-client";
 
 export function HomeContent() {
   return (
     <HeaderVariantClient variant="hero">
+      <PageViewTracker event="landingViewed" />
       <TopNav />
       <SlideDeck slides={publicHomeSlides} />
     </HeaderVariantClient>

--- a/src/app/instrumentation.test.tsx
+++ b/src/app/instrumentation.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PageViewTracker } from "../../components/PageViewTracker";
+import { StartScreenerLink } from "../../components/StartScreenerLink";
+import { recordedEvents, resetTelemetry } from "@/lib/telemetry";
+import AboutPage from "./about/page";
+import MethodsPage from "./methods/page";
+import ParticipantsPage from "./participants/page";
+
+/**
+ * SLICE-04 (issue #12) — the acceptance criteria, one describe per GIVEN.
+ */
+
+const names = () => recordedEvents().map((event) => event.name);
+const propsOf = (name: string) =>
+  recordedEvents().find((event) => event.name === name)?.props ?? {};
+
+describe("SLICE-04 entry-flow instrumentation", () => {
+  beforeEach(() => {
+    resetTelemetry();
+    window.sessionStorage.clear();
+  });
+
+  describe("GIVEN a visitor loads a page", () => {
+    it("THEN the named view event fires once with non-PII context", () => {
+      render(<PageViewTracker event="landingViewed" />);
+
+      expect(names()).toEqual(["landingViewed"]);
+      expect(Object.keys(propsOf("landingViewed")).sort()).toEqual([
+        "device_type",
+        "referrer_category",
+      ]);
+    });
+
+    it("THEN re-rendering does not fire it a second time", () => {
+      const { rerender } = render(<PageViewTracker event="landingViewed" />);
+      rerender(<PageViewTracker event="landingViewed" />);
+
+      expect(names()).toEqual(["landingViewed"]);
+    });
+  });
+
+  describe("GIVEN a visitor navigates to a supporting page", () => {
+    it.each([
+      [AboutPage, "aboutPageViewed"],
+      [MethodsPage, "methodsPageViewed"],
+      [ParticipantsPage, "participantsPageViewed"],
+    ])("THEN %# sends its view event", (Page, expected) => {
+      render(<Page />);
+      expect(names()).toContain(expected);
+    });
+  });
+
+  describe("GIVEN a visitor clicks the primary screener CTA", () => {
+    it("THEN startScreenerClicked fires with where on the page it happened", async () => {
+      const user = userEvent.setup();
+      render(
+        <StartScreenerLink href="/start" location="hero">
+          Start here
+        </StartScreenerLink>,
+      );
+
+      await user.click(screen.getByRole("link", { name: "Start here" }));
+
+      expect(names()).toEqual(["startScreenerClicked"]);
+      expect(propsOf("startScreenerClicked")).toEqual({
+        location_on_page: "hero",
+      });
+    });
+
+    it("THEN it fires on every click, unlike a view event", async () => {
+      const user = userEvent.setup();
+      render(
+        <StartScreenerLink href="/start" location="nav">
+          Start here
+        </StartScreenerLink>,
+      );
+
+      const link = screen.getByRole("link", { name: "Start here" });
+      await user.click(link);
+      await user.click(link);
+
+      expect(names()).toEqual(["startScreenerClicked", "startScreenerClicked"]);
+    });
+
+    it("THEN the link still navigates — telemetry does not swallow the click", async () => {
+      const user = userEvent.setup();
+      render(
+        <StartScreenerLink href="/start" location="hero">
+          Start here
+        </StartScreenerLink>,
+      );
+
+      const link = screen.getByRole("link", { name: "Start here" });
+      expect(link).toHaveAttribute("href", "/start");
+
+      const clickWasNotPrevented = link.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+      expect(clickWasNotPrevented).toBe(true);
+      await user.click(link);
+    });
+  });
+});

--- a/src/app/methods/page.tsx
+++ b/src/app/methods/page.tsx
@@ -1,6 +1,9 @@
+import { PageViewTracker } from "../../../components/PageViewTracker";
+
 export default function MethodsPage() {
   return (
     <main className="mx-auto w-full max-w-3xl px-6 py-16 md:py-24">
+      <PageViewTracker event="methodsPageViewed" />
       <section>
         <p className="font-data text-[0.6rem] uppercase tracking-[0.16em] text-ink-soft">
           Methods

--- a/src/app/participants/page.tsx
+++ b/src/app/participants/page.tsx
@@ -1,6 +1,9 @@
+import { PageViewTracker } from "../../../components/PageViewTracker";
+
 export default function ParticipantsPage() {
   return (
     <main className="mx-auto w-full max-w-3xl px-6 py-16 md:py-24">
+      <PageViewTracker event="participantsPageViewed" />
       <section>
         <p className="font-data text-[0.6rem] uppercase tracking-[0.16em] text-ink-soft">
           Participants

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  classifyDevice,
+  classifyReferrer,
+  configureTelemetry,
+  recordedEvents,
+  resetTelemetry,
+  track,
+  trackOnce,
+  type TelemetryEvent,
+} from "./telemetry";
+
+/**
+ * SLICE-04 (issue #12) — telemetry for entry flows.
+ *
+ * ZOMBIES ordering: Zero (no props / absent window), One, Many, Boundary
+ * (once-per-session idempotency), Interface (the pluggable sink), Exception
+ * (illegal keys rejected), Simple (the entry-flow events end to end).
+ */
+
+describe("telemetry", () => {
+  beforeEach(() => {
+    resetTelemetry();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ── Zero ──────────────────────────────────────────────────────────────────
+  it("records an event with no properties at all", () => {
+    track("landingViewed");
+    expect(recordedEvents()).toEqual([{ name: "landingViewed", props: {} }]);
+  });
+
+  // ── One ───────────────────────────────────────────────────────────────────
+  it("records a single event with its properties", () => {
+    track("startScreenerClicked", { location_on_page: "hero" });
+    expect(recordedEvents()).toEqual([
+      { name: "startScreenerClicked", props: { location_on_page: "hero" } },
+    ]);
+  });
+
+  // ── Many ──────────────────────────────────────────────────────────────────
+  it("records many events in the order they happened", () => {
+    track("aboutPageViewed");
+    track("methodsPageViewed");
+    track("participantsPageViewed");
+    expect(recordedEvents().map((e) => e.name)).toEqual([
+      "aboutPageViewed",
+      "methodsPageViewed",
+      "participantsPageViewed",
+    ]);
+  });
+
+  // ── Interface ─────────────────────────────────────────────────────────────
+  describe("pluggable sink", () => {
+    it("sends events to a configured sink instead of the buffer", () => {
+      const sent: TelemetryEvent[] = [];
+      configureTelemetry((event) => sent.push(event));
+
+      track("landingViewed", { device_type: "desktop" });
+
+      expect(sent).toEqual([
+        { name: "landingViewed", props: { device_type: "desktop" } },
+      ]);
+    });
+
+    it("does not let a throwing sink break the caller", () => {
+      configureTelemetry(() => {
+        throw new Error("provider is down");
+      });
+
+      expect(() => track("landingViewed")).not.toThrow();
+    });
+  });
+
+  // ── Exception ─────────────────────────────────────────────────────────────
+  describe("PII refusal", () => {
+    it.each([
+      "email",
+      "phone",
+      "name",
+      "full_name",
+      "address",
+      "ip",
+      "participant_id",
+    ])("drops the event when props carry %s", (key) => {
+      track("landingViewed", { [key]: "whatever" });
+      expect(recordedEvents()).toEqual([]);
+    });
+
+    it("drops the event when a value looks like an email address", () => {
+      track("landingViewed", { referrer_category: "bob@goodcitizens.us" });
+      expect(recordedEvents()).toEqual([]);
+    });
+
+    it("allows a hashed identifier through", () => {
+      track("landingViewed", { hashed_participant_id: "abc123" });
+      expect(recordedEvents()).toHaveLength(1);
+    });
+  });
+
+  // ── Boundary ──────────────────────────────────────────────────────────────
+  describe("once per session", () => {
+    it("records the first call and ignores repeats", () => {
+      trackOnce("landingViewed", { device_type: "mobile" });
+      trackOnce("landingViewed", { device_type: "mobile" });
+      trackOnce("landingViewed", { device_type: "mobile" });
+
+      expect(recordedEvents()).toHaveLength(1);
+    });
+
+    it("records again once the session is cleared", () => {
+      trackOnce("landingViewed");
+      window.sessionStorage.clear();
+      trackOnce("landingViewed");
+
+      expect(recordedEvents()).toHaveLength(2);
+    });
+
+    it("still records when sessionStorage is unavailable", () => {
+      vi.stubGlobal("sessionStorage", {
+        getItem: () => {
+          throw new Error("blocked by browser settings");
+        },
+        setItem: () => {
+          throw new Error("blocked by browser settings");
+        },
+        clear: () => {},
+      });
+
+      expect(() => trackOnce("landingViewed")).not.toThrow();
+      expect(recordedEvents()).toHaveLength(1);
+    });
+  });
+});
+
+describe("classifyDevice", () => {
+  it.each([
+    [320, "mobile"],
+    [767, "mobile"],
+    [768, "tablet"],
+    [1023, "tablet"],
+    [1024, "desktop"],
+  ])("classifies width %i as %s", (width, expected) => {
+    expect(classifyDevice(width)).toBe(expected);
+  });
+});
+
+describe("classifyReferrer", () => {
+  it("returns direct for an empty referrer", () => {
+    expect(classifyReferrer("")).toBe("direct");
+  });
+
+  it.each([
+    ["https://www.linkedin.com/feed/", "linkedin"],
+    ["https://lnkd.in/abc", "linkedin"],
+    ["https://www.google.com/search?q=big+mad", "search"],
+    ["https://duckduckgo.com/", "search"],
+    ["https://news.ycombinator.com/item?id=1", "other"],
+  ])("classifies %s as %s", (referrer, expected) => {
+    expect(classifyReferrer(referrer)).toBe(expected);
+  });
+
+  it("never returns the referrer itself, which could carry a path", () => {
+    const category = classifyReferrer("https://example.com/private/thing?t=1");
+    expect(category).not.toContain("private");
+    expect(category).toBe("other");
+  });
+});

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,16 +1,27 @@
 /**
- * Minimal event sink.
+ * Client-side telemetry for entry flows — SLICE-04 (issue #12).
  *
- * SLICE-04 (issue #12) owns wiring a real analytics provider. Until then this
- * buffers events on the client so the acceptance criteria for earlier slices
- * are testable and the event contract in the epics is exercised rather than
- * merely written down. Nothing leaves the browser.
+ * The sink is pluggable so a provider can be swapped in later without
+ * touching a single call site. Until one is configured, events buffer on
+ * `window.__bmTelemetry` and nothing leaves the browser.
+ *
+ * The PII refusal below is not decoration. This is a behavioural study whose
+ * landing page promises participants that analytics never carry identifying
+ * data; the cheapest way to keep that promise is to make the violation
+ * impossible at the one place every event passes through.
  */
+
+export type TelemetryProps = Record<string, string | number | boolean>;
 
 export type TelemetryEvent = {
   name: string;
-  props?: Record<string, string | number | boolean>;
+  props: TelemetryProps;
 };
+
+export type TelemetrySink = (event: TelemetryEvent) => void;
+
+export type DeviceType = "mobile" | "tablet" | "desktop";
+export type ReferrerCategory = "linkedin" | "search" | "direct" | "other";
 
 declare global {
   interface Window {
@@ -18,16 +29,121 @@ declare global {
   }
 }
 
-export function track(
-  name: string,
-  props?: Record<string, string | number | boolean>,
-): void {
+/**
+ * Property names that must never appear in analytics. `hashed_` prefixed keys
+ * are exempt: a hashed participant id is the intended way to correlate events.
+ */
+const FORBIDDEN_KEY =
+  /(^|_)(email|phone|name|address|ip|ssn|dob)($|_)|participant_id$/;
+const LOOKS_LIKE_EMAIL = /[^\s@]+@[^\s@]+\.[^\s@]+/;
+const LOOKS_LIKE_PHONE = /\+?\d[\d\s().-]{8,}/;
+
+let sink: TelemetrySink | null = null;
+
+/** Swap in a provider. Passing null restores the in-memory buffer. */
+export function configureTelemetry(next: TelemetrySink | null): void {
+  sink = next;
+}
+
+/** Clears the buffer and any configured sink. Test seam. */
+export function resetTelemetry(): void {
+  sink = null;
+  if (typeof window !== "undefined") window.__bmTelemetry = [];
+}
+
+function carriesPII(props: TelemetryProps): boolean {
+  return Object.entries(props).some(([key, value]) => {
+    if (key.startsWith("hashed_")) return false;
+    if (FORBIDDEN_KEY.test(key)) return true;
+    if (typeof value !== "string") return false;
+    return LOOKS_LIKE_EMAIL.test(value) || LOOKS_LIKE_PHONE.test(value);
+  });
+}
+
+export function track(name: string, props: TelemetryProps = {}): void {
   if (typeof window === "undefined") return;
+
+  // Drop rather than sanitize: a silently stripped property is a bug that
+  // ships, whereas a missing event shows up the first time anyone looks.
+  if (carriesPII(props)) {
+    console.warn(`[telemetry] dropped "${name}" — properties carry PII`);
+    return;
+  }
+
+  const event: TelemetryEvent = { name, props };
+
+  if (sink) {
+    // A failing analytics provider must never break the page it measures.
+    try {
+      sink(event);
+    } catch {
+      /* swallowed deliberately */
+    }
+    return;
+  }
+
   window.__bmTelemetry ??= [];
-  window.__bmTelemetry.push({ name, props });
+  window.__bmTelemetry.push(event);
+}
+
+/**
+ * Fires at most once per browser session. Used for view events, which would
+ * otherwise re-fire on every client-side navigation back to the page.
+ */
+export function trackOnce(name: string, props: TelemetryProps = {}): void {
+  if (typeof window === "undefined") return;
+
+  const key = `bm:seen:${name}`;
+
+  try {
+    if (window.sessionStorage.getItem(key)) return;
+    window.sessionStorage.setItem(key, "1");
+  } catch {
+    // Private browsing or blocked storage. Measuring twice beats not at all.
+  }
+
+  track(name, props);
 }
 
 export function recordedEvents(): TelemetryEvent[] {
   if (typeof window === "undefined") return [];
   return window.__bmTelemetry ?? [];
+}
+
+export function classifyDevice(width: number): DeviceType {
+  if (width < 768) return "mobile";
+  if (width < 1024) return "tablet";
+  return "desktop";
+}
+
+/**
+ * Deliberately lossy. The raw referrer can carry a path and query string that
+ * say more about a visitor than we have any business recording, so only the
+ * category survives.
+ */
+export function classifyReferrer(referrer: string): ReferrerCategory {
+  if (!referrer) return "direct";
+
+  let host: string;
+  try {
+    host = new URL(referrer).hostname.toLowerCase();
+  } catch {
+    return "other";
+  }
+
+  if (host.includes("linkedin") || host.includes("lnkd.in")) return "linkedin";
+
+  const searchHosts = ["google.", "bing.", "duckduckgo.", "search.", "ecosia."];
+  if (searchHosts.some((needle) => host.includes(needle))) return "search";
+
+  return "other";
+}
+
+/** The properties every entry-flow view event carries. */
+export function entryContext(): TelemetryProps {
+  if (typeof window === "undefined") return {};
+  return {
+    device_type: classifyDevice(window.innerWidth),
+    referrer_category: classifyReferrer(document.referrer),
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,6 +1206,11 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"


### PR DESCRIPTION
Closes #12. Parent EPIC: #8.

## Which part of the hypothesis this advances

EPIC-01's H1 claims a clearer landing page raises screener starts and completions. Every success metric in that epic — 60% scroll depth, 40% CTA clicks, drop-off points — is unmeasurable without this slice. It does not test the hypothesis; it makes the hypothesis testable.

## Acceptance criteria → the test that covers it

| AC | Covered by |
| --- | --- |
| `landingViewed` fires once per session with non-PII props | `instrumentation.test.tsx` — *the named view event fires once*, *re-rendering does not fire it again*; `BM-E2E-04` landing steps |
| `startScreenerClicked` fires before navigation with `location_on_page` | `instrumentation.test.tsx` — *fires with where on the page it happened*, *the link still navigates*; `BM-E2E-04` CTA steps |
| `aboutPageViewed` / `methodsPageViewed` / `participantsPageViewed` on render, payload shape asserted | `instrumentation.test.tsx` — *sends its view event* (parameterised over all three); `BM-E2E-04` |
| Pluggable interface for a later provider | `telemetry.test.ts` — *sends events to a configured sink*, *does not let a throwing sink break the caller* |
| No PII in telemetry | `telemetry.test.ts` — 9 refusal cases; `BM-E2E-04` audits every recorded property in a real browser |

## Design decisions worth reviewing

**The sink is one function.** `configureTelemetry(sink)` swaps in Mixpanel/Amplitude/a Firestore writer without touching a call site. Until then events buffer on `window.__bmTelemetry`. A throwing sink is swallowed — a failing analytics provider must not break the page it measures.

**PII refusal drops the event, not the property.** Forbidden key patterns (`email`, `phone`, `name`, `address`, `ip`, `ssn`, `dob`, raw `participant_id`) plus values matching email/phone shapes. A silently sanitized property is a bug that ships; a missing event shows up the first time anyone looks. `hashed_` keys are exempt, since a hashed participant id is how EPIC-03 intends to correlate.

**`referrer_category` is deliberately lossy.** The raw referrer carries a path and query string that say more about a visitor than we have any business recording. Only `linkedin` / `search` / `direct` / `other` survives.

**View events fire once per *session*, not once per mount.** App Router keeps components alive across client navigations, so a plain mount effect would re-fire on every return to the page and inflate the denominator of every funnel metric in the epic. Blocked `sessionStorage` degrades to measuring twice rather than not at all.

**`StartScreenerLink` does not `preventDefault` or navigate programmatically.** This click is the epic's headline metric, and an instrumented link that ate the navigation would trade the conversion for the measurement of it. A test asserts the click event is not cancelled.

## ZOMBIES

| | Covered |
| --- | --- |
| **Z** | event with no props at all; empty referrer → `direct`; absent `window` |
| **O** | single event with props |
| **M** | three events recorded in order |
| **B** | 767/768/1023/1024 device-width boundaries; once-per-session idempotency across three calls |
| **I** | the pluggable sink — configured sink receives events, buffer bypassed |
| **E** | throwing sink swallowed; unavailable `sessionStorage`; malformed referrer URL |
| **S** | `BM-E2E-04` walks landing → supporting page → CTA in a browser |

## Verification

- `yarn lint`, `yarn typecheck`, `yarn build` — pass
- `yarn test` — 63 passed / 9 files (up from 26 / 7)
- `yarn test:e2e` — 3 passed (BM-E2E-01, -02, -04), full Gherkin AC log green under `--verbose`

Two test bugs found and fixed while writing them, both worth naming since each would have produced a passing-but-worthless assertion: the `/about` step burned its own once-per-session flag on an earlier navigation, and the PII audit ran against an empty buffer — it would have vacuously passed over zero events.

## Accepted residuals

- **No provider is configured.** Events go nowhere by design; the slice's own note leaves the MVP storage decision open. EPIC-01's metrics cannot actually be read until one is wired.
- **`/start` still 404s.** `startScreenerClicked` fires and then navigates nowhere. Pre-existing; EPIC-02 owns that route.
- **`landingInfoSectionViewed`** from #10 still uses `track` directly rather than the once-per-session guard — intentional, it is per-section not per-page.
- Added `@testing-library/user-event` as a dev dependency for the click tests.
