### PR TITLE
SLICE: EPIC-01 Accessibility baseline (WCAG AA/AAA)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,29 @@ jobs:
 
       - name: Build
         run: yarn build
+
+  e2e:
+    name: E2E & accessibility
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Install Playwright browser
+        run: yarn playwright install --with-deps chromium
+
+      # Includes BM-E2E-03, the axe/keyboard/heading accessibility baseline.
+      # Until now e2e ran only on the local prepush hook, so a landmark or
+      # contrast regression could merge with every check green.
+      - name: E2E suite
+        run: yarn test:e2e --verbose

--- a/components/SlideSection.tsx
+++ b/components/SlideSection.tsx
@@ -15,6 +15,11 @@ export function SlideSection({
   const marker = String(index + 1).padStart(2, "0");
   const ref = useRef<HTMLElement>(null);
 
+  // The deck is one document, so the first slide's title is the page's h1 and
+  // every subsequent slide is a section beneath it. Rendering them all as h2
+  // left the landing page with no h1 at all.
+  const Heading = index === 0 ? "h1" : "h2";
+
   // landingInfoSectionViewed — fires once per section, the first time it
   // enters the viewport. Guarded because jsdom has no IntersectionObserver.
   useEffect(() => {
@@ -93,9 +98,9 @@ export function SlideSection({
         >
           {marker}
         </p>
-        <h2 className="font-display text-[clamp(2rem,5vw,3rem)] font-normal leading-[1.1]">
+        <Heading className="font-display text-[clamp(2rem,5vw,3rem)] font-normal leading-[1.1]">
           {slide.title}
-        </h2>
+        </Heading>
         {slide.subtitle && (
           <p className="mt-4 text-lg leading-relaxed text-ink-soft">
             {slide.subtitle}

--- a/docs/delivery/standards.md
+++ b/docs/delivery/standards.md
@@ -50,7 +50,7 @@ Rules:
 - **All four must pass. No suppression.** Do not silence a rule to get green; fix the code, or annotate with an `eslint-disable-next-line ... -- <reason> (#issue)` naming why the rule genuinely cannot apply.
 - **`yarn ci` is currently broken and is not the gate.** It chains `yarn test:ci`, which needs `@vitest/coverage-v8` — not installed. Until that dependency lands, run the four commands above individually. Do not report `yarn ci` as passing; it does not run.
 - **Coverage is not gated and not measured.** There is no threshold and no upload. Do not claim a coverage gate that does not exist.
-- **E2E is not in CI.** `yarn test:e2e` runs on the husky `prepush` hook only. Any change touching the landing page, routing, or landmarks must run it locally — CI will not catch a break. `--verbose` prints the Gherkin AC log.
+- **E2E now runs in CI** (`E2E & accessibility` job, added by SLICE-03), as well as on the husky `prepush` hook. `--verbose` prints the Gherkin AC log. It covers BM-E2E-01 through -04, including the axe/keyboard/heading accessibility baseline.
 - **Two PR guards run on top of CI**, and both are title-sensitive:
   - `pr-title-guard` — the PR title must start with `EPIC:` or `SLICE:`.
   - `slice-test-guard` — a `SLICE:` PR must change at least one `*.test.*` / `*.spec.*` file. A slice with no test change cannot merge, by design.

--- a/e2e/BM-E2E-03.spec.ts
+++ b/e2e/BM-E2E-03.spec.ts
@@ -1,0 +1,166 @@
+import AxeBuilder from "@axe-core/playwright";
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * BM-E2E-03 — SLICE-03 (issue #11).
+ * Accessibility baseline across every top-level page.
+ *
+ * This is the automated floor, not the whole story: axe catches roughly a
+ * third of real barriers. The keyboard and heading checks below cover things
+ * axe cannot see, and manual screen-reader passes remain necessary.
+ */
+
+const PAGES = [
+  { path: "/", name: "landing" },
+  { path: "/about", name: "about" },
+  { path: "/methods", name: "methods" },
+  { path: "/participants", name: "participants" },
+];
+
+const acVerboseFlag = (process.env.AC_VERBOSE ?? "").toLowerCase();
+const logPasses = acVerboseFlag === "1" || acVerboseFlag === "true";
+
+const runStep = async (description: string, fn: () => Promise<void>) => {
+  try {
+    await fn();
+    if (logPasses) console.info(`[AC PASS] ${description}`);
+  } catch (error) {
+    console.error(`[AC FAIL] ${description}`);
+    throw error;
+  }
+};
+
+const scan = (page: Page) =>
+  new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+
+test.describe("BM-E2E-03 – Accessibility baseline", () => {
+  for (const { path, name } of PAGES) {
+    test(`${name} (${path}) has no WCAG A/AA violations`, async ({ page }) => {
+      await runStep(
+        `GIVEN a user with assistive technology opens ${path} WHEN the page is scanned THEN no WCAG A/AA violation is reported`,
+        async () => {
+          await page.goto(path);
+          const results = await scan(page);
+
+          // Name the rules rather than dumping the object — a bare count
+          // tells a reader nothing about what broke.
+          const summary = results.violations.map(
+            (v) => `${v.id} (${v.impact}) ×${v.nodes.length}`,
+          );
+          expect(summary, `violations on ${path}`).toEqual([]);
+        },
+      );
+    });
+
+    test(`${name} (${path}) has exactly one h1 and no skipped heading levels`, async ({
+      page,
+    }) => {
+      await runStep(
+        `GIVEN a screen reader user navigates ${path} by heading WHEN they traverse the hierarchy THEN there is a single h1 and no level is skipped`,
+        async () => {
+          await page.goto(path);
+
+          const levels = await page
+            .locator("h1, h2, h3, h4, h5, h6")
+            .evaluateAll((nodes) =>
+              nodes.map((node) => Number(node.tagName.slice(1))),
+            );
+
+          expect(
+            levels.filter((l) => l === 1),
+            `h1 count on ${path}`,
+          ).toHaveLength(1);
+          expect(levels[0], `first heading on ${path}`).toBe(1);
+
+          for (let i = 1; i < levels.length; i += 1) {
+            expect(
+              levels[i] - levels[i - 1],
+              `heading jump at index ${i} on ${path} (${levels.join(",")})`,
+            ).toBeLessThanOrEqual(1);
+          }
+        },
+      );
+    });
+  }
+
+  test("landmarks let a screen reader reach main content directly", async ({
+    page,
+  }) => {
+    await runStep(
+      "GIVEN a screen reader user visits any top-level page WHEN they navigate by landmark THEN banner, main and contentinfo are present exactly once",
+      async () => {
+        for (const { path } of PAGES) {
+          await page.goto(path);
+          await expect(page.getByRole("main"), `main on ${path}`).toHaveCount(
+            1,
+          );
+          await expect(
+            page.getByRole("contentinfo"),
+            `contentinfo on ${path}`,
+          ).toHaveCount(1);
+          await expect(
+            page.getByRole("banner"),
+            `banner on ${path}`,
+          ).toHaveCount(1);
+        }
+      },
+    );
+  });
+
+  test("keyboard focus is always visible and never trapped", async ({
+    page,
+  }) => {
+    await runStep(
+      "GIVEN a keyboard-only user tabs through the landing page WHEN focus moves THEN it is visible, ordered, and escapable",
+      async () => {
+        await page.goto("/");
+
+        const seen: string[] = [];
+
+        for (let i = 0; i < 25; i += 1) {
+          await page.keyboard.press("Tab");
+
+          const focused = await page.evaluate(() => {
+            const el = document.activeElement as HTMLElement | null;
+            if (!el || el === document.body) return null;
+
+            // The Next.js dev-tools overlay is focusable and unstyled, but it
+            // exists only because this harness runs `yarn dev`. It is not part
+            // of the product and no visitor will ever reach it.
+            if (el.tagName.toLowerCase() === "nextjs-portal") {
+              return { tag: "nextjs-portal", label: "", hasIndicator: true };
+            }
+
+            const style = getComputedStyle(el);
+            const outlineWidth = parseFloat(style.outlineWidth || "0");
+            return {
+              tag: el.tagName.toLowerCase(),
+              label: (el.textContent ?? "").trim().slice(0, 40),
+              // Any of these is an acceptable focus affordance.
+              hasIndicator:
+                (style.outlineStyle !== "none" && outlineWidth > 0) ||
+                style.boxShadow !== "none" ||
+                style.textDecorationLine.includes("underline"),
+            };
+          });
+
+          if (!focused) break;
+
+          expect(
+            focused.hasIndicator,
+            `no visible focus indicator on <${focused.tag}> "${focused.label}"`,
+          ).toBe(true);
+
+          seen.push(`${focused.tag}:${focused.label}`);
+        }
+
+        // Something must be reachable, and tabbing must not cycle forever on
+        // one element — the signature of a focus trap.
+        expect(seen.length).toBeGreaterThan(3);
+        expect(new Set(seen).size).toBeGreaterThan(1);
+      },
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "zod": "^4.2.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.57.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",

--- a/src/app/layout-header.tsx
+++ b/src/app/layout-header.tsx
@@ -22,9 +22,12 @@ export function LayoutHeader({
           <p className="font-data text-[0.6rem] uppercase tracking-[0.16em] text-ink-soft">
             Public Orientation
           </p>
-          <h1 className="mt-2 font-display text-2xl font-normal">
+          {/* Site name, not the page's heading — every page below carries its
+              own h1, and two of them is worse than none for a screen reader
+              navigating by heading. */}
+          <p className="mt-2 font-display text-2xl font-normal">
             Big Mad Study
-          </h1>
+          </p>
         </div>
         <nav
           aria-label="Primary"

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,13 @@
   resolved "https://registry.yarnpkg.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz#ad5549322dfe9d153d4b4dd6f7ff2ae234b06e24"
   integrity sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==
 
+"@axe-core/playwright@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz#4a14cd41eecc1ff01edcdc3db12a2e88acd34180"
+  integrity sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==
+  dependencies:
+    axe-core "~4.12.1"
+
 "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
@@ -1802,6 +1809,11 @@ axe-core@^4.10.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.0.tgz#16f74d6482e343ff263d4f4503829e9ee91a86b6"
   integrity sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==
+
+axe-core@~4.12.1:
+  version "4.12.1"
+  resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz#69fe2bf6dfc0b24973af91b1d8e945f79e1b7c44"
+  integrity sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==
 
 axios@^1.12.0:
   version "1.13.2"


### PR DESCRIPTION
Closes #11. Parent EPIC: #8.

## Which part of the hypothesis this advances

EPIC-01's third acceptance criterion — assistive-tech users encounter sane landmarks, descriptive headings, and meaningful link text. H1 claims clarity raises screener starts; a page a screen reader cannot navigate has no clarity for that visitor at all.

## Acceptance criteria → the test that covers it

| AC | Covered by |
| --- | --- |
| Text meets WCAG AA contrast, key body text AAA where practical | `palette.test.ts` (14 assertions, from #10) + axe `color-contrast` across all four pages |
| Keyboard focus always visible, logical order, no traps | `BM-E2E-03` — *keyboard focus is always visible and never trapped* |
| Screen reader reaches main content quickly, sensible hierarchy, single `<h1>` | `BM-E2E-03` — *has exactly one h1 and no skipped heading levels* (per page) + *landmarks let a screen reader reach main content directly* |
| Automated accessibility checks in CI | new `E2E & accessibility` job in `ci.yml` |

## Two real defects, both invisible to the existing suite

**The landing page had no `<h1>` at all.** Every slide rendered `h2`, so a screen reader user navigating by heading found a document with no title. The first slide's title is now the `h1`; the rest stay `h2` beneath it.

**Every supporting page had two `<h1>`s** — one in the layout header for the site name, one for the page itself. The layout's is now a `<p>`. It was branding, not a heading, and two `h1`s are worse than none when navigating by heading.

Worth noting for the reviewer: **axe reported zero violations before and after.** Both defects are structural, which is exactly the category automated scanning is weakest at. That is why BM-E2E-03 adds heading-hierarchy, landmark, and keyboard checks alongside the axe run rather than treating a clean axe report as done.

## What BM-E2E-03 actually checks

- axe with `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa` on `/`, `/about`, `/methods`, `/participants`
- exactly one `h1` per page, first heading is the `h1`, no level skipped
- `banner` / `main` / `contentinfo` present exactly once on every page
- tabbing 25 stops: every focused element has a visible affordance (outline, box-shadow, or underline), more than one distinct element is reachable, and focus never cycles on a single element

Failures name the offending rule and element rather than dumping a count.

## E2E now runs in CI

Previously e2e ran only on the local prepush hook, so a landmark or contrast regression could merge with every check green. `ci.yml` gains an `E2E & accessibility` job covering BM-E2E-01 through -04. `docs/delivery/standards.md` said e2e was not in CI and is updated to match.

## Verification

- `yarn lint`, `yarn typecheck`, `yarn build` — pass
- `yarn test` — 26 passed / 7 files
- `yarn test:e2e` — 12 passed (10 of them BM-E2E-03)
- Both heading defects confirmed red before the fix and green after

## Accepted residuals

- **axe catches perhaps a third of real barriers.** This is a floor, not a ceiling. A manual screen-reader pass (VoiceOver/NVDA) is still needed and is not in this slice.
- **`<nextjs-portal>` is skipped in the keyboard check.** The Next dev-tools overlay is focusable and unstyled, but exists only because the harness runs `yarn dev` — it is not part of the product. Running e2e against a production build would remove the exception; worth doing, out of scope here.
- **AAA is met for the palette but not claimed page-wide.** The slice says "stretch to AAA where reasonable"; the token contrast suite enforces AAA on text tokens, and axe checks AA.
- **Mono micro-labels remain ~10px.** They pass AAA on contrast; size remains a type-scale question, unresolved since #10.
- **Reduced-motion** is honored via the media query in `globals.css`, untested here — nothing currently animates.
