### PR TITLE
SLICE: EPIC-04 Check-in entry schema & consent-linkage guard

### DIFF
--- a/src/lib/checkin/store.test.ts
+++ b/src/lib/checkin/store.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import type { CheckInEntry, NewCheckIn } from "./types";
+import {
+  analysisEntries,
+  storeCheckIn,
+  type CheckInRepository,
+  type ConsentLookup,
+} from "./store";
+import type { ConsentRecord } from "@/lib/consent/types";
+
+/**
+ * SLICE-04-01 (issue #44) — entry schema & consent-linkage guard.
+ *
+ * The two structural promises: nothing is stored without a linkable consent
+ * record of the required scopes, and pilot data can never reach an analysis
+ * query. Both are the kind of guarantee that must be proven by a failing
+ * test, not read off the code.
+ */
+
+const CONSENT: ConsentRecord = {
+  hashedParticipantId: "hp_abc",
+  consentVersion: "draft-0",
+  scopes: { study: true, voice: false, sms: true },
+  agreedAt: "2026-08-01T00:00:00Z",
+};
+
+const smsEntry = (overrides: Partial<NewCheckIn> = {}): NewCheckIn => ({
+  hashedParticipantId: "hp_abc",
+  channel: "sms",
+  narrative: "the routing app rerouted me twice",
+  destination: "tool",
+  intensity: 7,
+  recency: "just_now",
+  pilot: false,
+  ...overrides,
+});
+
+function harness(consents: ConsentRecord[] = [CONSENT]) {
+  const stored: CheckInEntry[] = [];
+  const refusals: { reason: string }[] = [];
+  const repo: CheckInRepository = {
+    persist: async (entry) => {
+      stored.push(entry);
+      return entry;
+    },
+    all: async () => stored,
+  };
+  const lookup: ConsentLookup = async (id) =>
+    consents.find((c) => c.hashedParticipantId === id) ?? null;
+  return {
+    repo,
+    lookup,
+    stored,
+    refusals,
+    logRefusal: (reason: string) => refusals.push({ reason }),
+  };
+}
+
+describe("SLICE-04-01 check-in storage", () => {
+  // ── Zero: everything optional skipped ────────────────────────────────────
+  it("stores an entry with every optional field skipped", async () => {
+    const h = harness();
+    const result = await storeCheckIn(
+      smsEntry({
+        destination: "skipped",
+        intensity: "skipped",
+        recency: "skipped",
+      }),
+      h.repo,
+      h.lookup,
+      h.logRefusal,
+    );
+
+    expect(result.stored).toBe(true);
+    expect(h.stored[0].destination).toBe("skipped");
+    expect(h.stored[0].intensity).toBe("skipped");
+    expect(h.stored[0].recency).toBe("skipped");
+  });
+
+  // ── One / Simple ─────────────────────────────────────────────────────────
+  it("round-trips a full entry with all fields typed and the consent version stamped", async () => {
+    const h = harness();
+    await storeCheckIn(smsEntry(), h.repo, h.lookup, h.logRefusal);
+
+    expect(h.stored).toHaveLength(1);
+    const entry = h.stored[0];
+    expect(entry.destination).toBe("tool");
+    expect(entry.intensity).toBe(7);
+    expect(entry.recency).toBe("just_now");
+    expect(entry.consentVersion).toBe("draft-0");
+    expect(entry.receivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  // ── Exception: the consent guard ─────────────────────────────────────────
+  describe("consent-linkage guard", () => {
+    it("refuses an entry with no linkable consent record", async () => {
+      const h = harness([]);
+      const result = await storeCheckIn(
+        smsEntry(),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(result.stored).toBe(false);
+      expect(h.stored).toHaveLength(0);
+      expect(h.refusals).toHaveLength(1);
+      expect(h.refusals[0].reason).toBe("no_consent_record");
+    });
+
+    it("refuses a voice entry when the biometric scope is missing", async () => {
+      const h = harness(); // CONSENT has voice: false
+      const result = await storeCheckIn(
+        smsEntry({ channel: "voice" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(result.stored).toBe(false);
+      expect(h.refusals[0].reason).toBe("missing_scope_voice");
+    });
+
+    it("refuses when study consent itself is revoked", async () => {
+      const h = harness([
+        { ...CONSENT, scopes: { ...CONSENT.scopes, study: false } },
+      ]);
+      const result = await storeCheckIn(
+        smsEntry(),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(result.stored).toBe(false);
+      expect(h.refusals[0].reason).toBe("missing_scope_study");
+    });
+
+    it("logs the refusal without the entry content", async () => {
+      const h = harness([]);
+      await storeCheckIn(
+        smsEntry({ narrative: "something deeply personal" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(JSON.stringify(h.refusals)).not.toContain("deeply personal");
+    });
+  });
+
+  // ── Boundary: intensity edges ────────────────────────────────────────────
+  it.each([0, 10])(
+    "accepts intensity %i at the boundary",
+    async (intensity) => {
+      const h = harness();
+      const result = await storeCheckIn(
+        smsEntry({ intensity }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      expect(result.stored).toBe(true);
+    },
+  );
+
+  it("rejects an out-of-range intensity rather than clamping it", async () => {
+    const h = harness();
+    const result = await storeCheckIn(
+      smsEntry({ intensity: 11 as never }),
+      h.repo,
+      h.lookup,
+      h.logRefusal,
+    );
+    expect(result.stored).toBe(false);
+    expect(h.refusals[0].reason).toBe("invalid_intensity");
+  });
+
+  // ── Interface / Many: pilot separation ───────────────────────────────────
+  describe("pilot separation", () => {
+    it("excludes pilot rows from analysis queries by construction", async () => {
+      const h = harness();
+      await storeCheckIn(
+        smsEntry({ pilot: true, narrative: "pilot one" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      await storeCheckIn(
+        smsEntry({ narrative: "study one" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      await storeCheckIn(
+        smsEntry({ pilot: true, narrative: "pilot two" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      const analysable = await analysisEntries(h.repo);
+
+      expect(analysable).toHaveLength(1);
+      expect(analysable[0].narrative).toBe("study one");
+    });
+
+    it("marks pilot on the stored entry immutably at ingest", async () => {
+      const h = harness();
+      await storeCheckIn(
+        smsEntry({ pilot: true }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      expect(h.stored[0].pilot).toBe(true);
+    });
+  });
+});

--- a/src/lib/checkin/store.ts
+++ b/src/lib/checkin/store.ts
@@ -1,0 +1,81 @@
+import type { ConsentRecord } from "@/lib/consent/types";
+import type { Channel, CheckInEntry, NewCheckIn } from "./types";
+
+/**
+ * Check-in storage with the consent-linkage guard — SLICE-04-01 (issue #44).
+ *
+ * Collection without consent must be impossible, not discouraged, so the
+ * guard lives in the one function every channel must pass through rather
+ * than in each channel's good intentions. Refusals are logged by reason
+ * only — a refused entry's content is exactly the thing we had no right
+ * to keep.
+ */
+
+export type CheckInRepository = {
+  persist(entry: CheckInEntry): Promise<CheckInEntry>;
+  all(): Promise<readonly CheckInEntry[]>;
+};
+
+export type ConsentLookup = (
+  hashedParticipantId: string,
+) => Promise<ConsentRecord | null>;
+
+export type RefusalLog = (reason: string) => void;
+
+export type StoreResult =
+  | { stored: true; entry: CheckInEntry }
+  | { stored: false; reason: string };
+
+const SCOPE_FOR_CHANNEL: Record<Channel, "voice" | null> = {
+  sms: null, // receiving an SMS needs study consent only; sending needs sms scope (#35, #49)
+  voice: "voice",
+};
+
+function invalidIntensity(intensity: NewCheckIn["intensity"]): boolean {
+  if (intensity === "skipped") return false;
+  return !Number.isInteger(intensity) || intensity < 0 || intensity > 10;
+}
+
+export async function storeCheckIn(
+  incoming: NewCheckIn,
+  repo: CheckInRepository,
+  findConsent: ConsentLookup,
+  logRefusal: RefusalLog,
+): Promise<StoreResult> {
+  const refuse = (reason: string): StoreResult => {
+    logRefusal(reason);
+    return { stored: false, reason };
+  };
+
+  const consent = await findConsent(incoming.hashedParticipantId);
+  if (!consent) return refuse("no_consent_record");
+  if (!consent.scopes.study) return refuse("missing_scope_study");
+
+  const channelScope = SCOPE_FOR_CHANNEL[incoming.channel];
+  if (channelScope && !consent.scopes[channelScope]) {
+    return refuse(`missing_scope_${channelScope}`);
+  }
+
+  if (invalidIntensity(incoming.intensity)) return refuse("invalid_intensity");
+
+  const entry: CheckInEntry = Object.freeze({
+    ...incoming,
+    receivedAt: new Date().toISOString(),
+    consentVersion: consent.consentVersion,
+  });
+
+  await repo.persist(entry);
+  return { stored: true, entry };
+}
+
+/**
+ * The only sanctioned read path for analysis. Pilot rows are excluded here,
+ * by construction — an analysis that wants pilot data has to go around this
+ * function, and doing so is the defect the tests exist to catch.
+ */
+export async function analysisEntries(
+  repo: CheckInRepository,
+): Promise<readonly CheckInEntry[]> {
+  const entries = await repo.all();
+  return entries.filter((entry) => !entry.pilot);
+}

--- a/src/lib/checkin/types.ts
+++ b/src/lib/checkin/types.ts
@@ -1,0 +1,53 @@
+/**
+ * The check-in entry — SLICE-04-01 (issue #44).
+ *
+ * Field names mirror the pre-registration's Operational definitions verbatim
+ * (docs/compliance/pre-registration.md). The registration is the spec; the
+ * code follows it, and changes to the instrument go through the registration
+ * first.
+ *
+ * Skips are first-class values, not nulls: the landing page promises any
+ * question can be skipped, and a skipped answer is data (it is counted),
+ * where a null is an accident.
+ */
+
+export type Destination =
+  | "tool"
+  | "other_people"
+  | "myself"
+  | "nowhere"
+  /** Pilot-only fifth option; frozen out or in by SLICE-04-03. */
+  | { other: string }
+  | "skipped";
+
+export type Recency =
+  | "just_now"
+  | "within_hour"
+  | "earlier_today"
+  | "before_today"
+  | "skipped";
+
+export type Intensity = number | "skipped"; // 0–10 integer when present
+
+export type Channel = "sms" | "voice";
+
+/** What a channel hands to storage. */
+export type NewCheckIn = {
+  hashedParticipantId: string;
+  channel: Channel;
+  narrative: string;
+  destination: Destination;
+  intensity: Intensity;
+  recency: Recency;
+  /** Immutable at ingest — pilot data must never mix with study data. */
+  pilot: boolean;
+};
+
+/** What storage persists: the entry plus what only storage may stamp. */
+export type CheckInEntry = Readonly<
+  NewCheckIn & {
+    receivedAt: string;
+    /** The consent text version in force when this entry was accepted. */
+    consentVersion: string;
+  }
+>;

--- a/src/lib/consent/types.ts
+++ b/src/lib/consent/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Consent records — shared between the screener gate (SLICE-00-03, #32) and
+ * check-in storage (SLICE-04-01, #44).
+ *
+ * The three scopes mirror the consent document's three separately-refusable
+ * agreements. Bundled consent is not consent, so they are independent
+ * booleans rather than a single flag.
+ */
+
+export type ConsentScopes = {
+  /** The study itself. Required — without it nothing may be stored. */
+  study: boolean;
+  /** Biometric consent for voice recordings (BIPA-grade, separate). */
+  voice: boolean;
+  /** TCPA consent to receive recurring SMS prompts. */
+  sms: boolean;
+};
+
+export type ConsentRecord = {
+  hashedParticipantId: string;
+  /** Which text they agreed to — the exact version shown, never inferred. */
+  consentVersion: string;
+  scopes: ConsentScopes;
+  agreedAt: string;
+};


### PR DESCRIPTION
Closes #44. Parent EPIC: #43.

The structural spine of capture: a typed entry mirroring the registration's Operational definitions, a storage guard that makes collection-without-consent impossible rather than discouraged, and an analysis read path that excludes pilot rows by construction.

**ZOMBIES:** Z = all-optional-skipped entry · O/S = full round-trip with consent version stamped · M = pilot/study interleaving · B = intensity 0/10 accepted, 11 refused not clamped · I = injected repository + the analysisEntries contract · E = four refusal reasons, logged without content.

**Verification:** 11 new tests, red first; lint/typecheck/build green; 88 unit tests total.

**Accepted residuals:** persistence is an injected interface — the Firestore adapter lands with the backend, behind the guard. `receivedAt` is server-stamped at store time, not participant-reported (recency covers the moment-to-report gap per the registration).