### PR TITLE
SLICE: EPIC-00 Consent gate at /start

### DIFF
--- a/components/ConsentGate.tsx
+++ b/components/ConsentGate.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  agreements,
+  CONSENT_VERSION,
+  consentSections,
+} from "@/content/consent";
+import type { ConsentScopes } from "@/lib/consent/types";
+import { track, trackOnce } from "@/lib/telemetry";
+
+export type ConsentDecision =
+  | { declined: true }
+  | { declined: false; consentVersion: string; scopes: ConsentScopes };
+
+/**
+ * The consent gate — SLICE-00-03 (issue #32).
+ *
+ * Renders before any personal-data question and collects agreement, never
+ * data: there are no text inputs here by design, and a test asserts it.
+ * The three agreements are independently refusable; declining is a single
+ * click that needs no checkboxes — it must never be harder than accepting.
+ */
+export function ConsentGate({
+  onDecision,
+}: {
+  onDecision: (decision: ConsentDecision) => void;
+}) {
+  const [study, setStudy] = useState(false);
+  const [age, setAge] = useState(false);
+  const [voice, setVoice] = useState(false);
+  const [sms, setSms] = useState(false);
+
+  useEffect(() => {
+    trackOnce("consentPresented", { consent_version: CONSENT_VERSION });
+  }, []);
+
+  const accept = () => {
+    track("consentAccepted", {
+      consent_version: CONSENT_VERSION,
+      biometric_scope: voice,
+      sms_scope: sms,
+    });
+    onDecision({
+      declined: false,
+      consentVersion: CONSENT_VERSION,
+      scopes: { study: true, voice, sms },
+    });
+  };
+
+  const decline = () => {
+    track("consentDeclined", { consent_version: CONSENT_VERSION });
+    onDecision({ declined: true });
+  };
+
+  const checkboxRow = (
+    checked: boolean,
+    onChange: (next: boolean) => void,
+    label: string,
+  ) => (
+    <label className="flex items-start gap-3 border-t border-hairline pt-4">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="mt-1 h-4 w-4 accent-[var(--accent)]"
+      />
+      <span className="text-[0.95rem] leading-[1.6]">{label}</span>
+    </label>
+  );
+
+  return (
+    <div>
+      {CONSENT_VERSION.startsWith("draft") && (
+        <p className="mb-8 border border-rule px-4 py-3 font-data text-[0.63rem] uppercase tracking-[0.18em] text-ink-soft">
+          Draft consent — not yet approved for participant use
+        </p>
+      )}
+
+      <p className="font-data text-[0.6rem] uppercase tracking-[0.16em] text-ink-soft">
+        Before anything else
+      </p>
+      <h1 className="mt-4 font-display text-[clamp(2rem,5vw,3rem)] font-normal leading-[1.1]">
+        What you&rsquo;d be agreeing to
+      </h1>
+      <p className="mt-4 text-lg leading-relaxed text-ink-soft">
+        Read this first. We don&rsquo;t ask you a single question until
+        you&rsquo;ve decided — and deciding no takes one click.
+      </p>
+
+      {consentSections.map((section) => (
+        <section key={section.heading} className="mt-10">
+          <h2 className="font-display text-xl font-normal">
+            {section.heading}
+          </h2>
+          {section.body.map((paragraph) => (
+            <p key={paragraph} className="mt-3 leading-[1.7]">
+              {paragraph}
+            </p>
+          ))}
+        </section>
+      ))}
+
+      <section className="mt-12">
+        <h2 className="font-display text-xl font-normal">Your agreement</h2>
+        <p className="mt-3 leading-[1.7] text-ink-soft">
+          These are separate on purpose. You can say yes to some and no to
+          others; only the first two are required to take part.
+        </p>
+        <div className="mt-6 space-y-4">
+          {checkboxRow(study, setStudy, agreements.study)}
+          {checkboxRow(age, setAge, agreements.age)}
+          {checkboxRow(voice, setVoice, agreements.voice)}
+          {checkboxRow(sms, setSms, agreements.sms)}
+        </div>
+      </section>
+
+      <div className="mt-12 flex flex-wrap items-center gap-8">
+        <button
+          type="button"
+          onClick={accept}
+          disabled={!study || !age}
+          className="rounded-full border border-accent px-6 py-3 font-data text-[0.63rem] uppercase tracking-[0.18em] text-accent disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          I agree — continue
+        </button>
+        <button
+          type="button"
+          onClick={decline}
+          className="border-b border-rule pb-[0.15rem] font-data text-[0.63rem] uppercase tracking-[0.18em] text-ink-soft hover:border-accent hover:text-accent"
+        >
+          No thanks
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docs/compliance/pre-registration.md
+++ b/docs/compliance/pre-registration.md
@@ -28,9 +28,9 @@ The distinctive question is not how bad work feels but **where the frustration g
 
 - **H1:** Within the same participant, moments involving automated or algorithmic systems are more likely to be displaced onto people (other people, or the self) than that participant's moments not involving such systems.
 - **H0:** Displacement destination is independent of system involvement within person.
-- **Meaningful magnitude:** odds ratio **≥ 1.5** for the within-person fixed effect. Below that, an effect of this kind is unlikely to be distinguishable from residual moment-level confounding (time of day, workload spikes) in an observational design of this size — so anything smaller is reported as no meaningful association *regardless of statistical significance*.
+- **Meaningful magnitude:** odds ratio **≥ 1.5** for the within-person fixed effect. Below that, an effect of this kind is unlikely to be distinguishable from residual moment-level confounding (time of day, workload spikes) in an observational design of this size — so anything smaller is reported as no meaningful association _regardless of statistical significance_.
 
-The comparison is within-person by design: each participant serves as their own control, so stable confounds — profession, temperament, income, the particular week — are absorbed by the person-level intercept. This is also the analysis most robust to the study's unpaid opt-in sampling (see Sampling): a motivated sample biases *who enrolls*, not the contrast between one person's system-involved and non-system moments.
+The comparison is within-person by design: each participant serves as their own control, so stable confounds — profession, temperament, income, the particular week — are absorbed by the person-level intercept. This is also the analysis most robust to the study's unpaid opt-in sampling (see Sampling): a motivated sample biases _who enrolls_, not the contrast between one person's system-involved and non-system moments.
 
 ### Secondary — H2: intensity
 
@@ -53,9 +53,9 @@ Carried from the delivery epics and evaluated operationally, not in the scientif
 ## Operational definitions
 
 - **System involvement** (moment-level predictor) — whether an app, dashboard, metric, algorithm, or automated system was part of the moment. **Coded from the narrative**, not asked: asking would prime participants toward the hypothesis. Two independent coders, blind to exposure score and cohort, working from a written codebook on transcripts (never audio); disagreements resolved by a third. Coders code a common **20% overlap sample**; Cohen's **κ ≥ 0.70 required** on that sample before the variable is used at all — below the floor, the primary analysis is reported as failed rather than patched. Unintelligible entries are flagged uncodable, not guessed.
-- **Displacement destination** (moment-level outcome) — participant self-report, forced choice at each check-in: *the tool / other people / myself / nowhere*, with the tie-break instruction "pick where **most** of it went." For the primary analysis the outcome is **binary: person-directed** (other people or self) **vs not** (tool or nowhere). Categories are frozen only after the disclosed pilot (see Pilot).
+- **Displacement destination** (moment-level outcome) — participant self-report, forced choice at each check-in: _the tool / other people / myself / nowhere_, with the tie-break instruction "pick where **most** of it went." For the primary analysis the outcome is **binary: person-directed** (other people or self) **vs not** (tool or nowhere). Categories are frozen only after the disclosed pilot (see Pilot).
 - **Frustration intensity** (moment-level, secondary) — single self-rating 0–10 per check-in, verbally anchored in every prompt: "0 = barely registered, 10 = as worked up as you get."
-- **Recency** (moment-level covariate/screen) — "when did this happen?": *just now / within the last hour / earlier today / before today*.
+- **Recency** (moment-level covariate/screen) — "when did this happen?": _just now / within the last hour / earlier today / before today_.
 - **Exposure** (person-level) — the screener's continuous automation-exposure score. The `heavy_ai` / `light_ai` / `low_ai` labels derived from it are used for recruitment stratification and readable reporting only; **analysis uses the continuous score**, because trichotomizing a continuous measure discards information.
 
 ## Design
@@ -67,7 +67,7 @@ Carried from the delivery epics and evaluated operationally, not in the scientif
 
 ## Pilot (design phase, disclosed)
 
-Before registration of the final instrument wording, a pilot of **10–15 people from the authors' extended network, 2–3 days each, using the real SMS flow** finalizes the destination response options. The pilot includes a fifth option — *somewhere else (say where)* — with free text; the four categories are frozen only if ≥ 90% of pilot entries land cleanly in them, and revised before freezing if not. **Pilot data is design data:** it is excluded from all analyses and no pilot participant may enroll in the study proper.
+Before registration of the final instrument wording, a pilot of **10–15 people from the authors' extended network, 2–3 days each, using the real SMS flow** finalizes the destination response options. The pilot includes a fifth option — _somewhere else (say where)_ — with free text; the four categories are frozen only if ≥ 90% of pilot entries land cleanly in them, and revised before freezing if not. **Pilot data is design data:** it is excluded from all analyses and no pilot participant may enroll in the study proper.
 
 ## Sampling
 
@@ -75,7 +75,7 @@ Before registration of the final instrument wording, a pilot of **10–15 people
 - **Recruitment:** Public and **unpaid**, via LinkedIn and extended network initially. **[DECIDE]** — additional channels; channel choice materially affects sample composition.
 - **Compensation:** None. Participants receive access to their own entries and patterns, and the published findings — no payment, gift, or lottery.
 - **What unpaid opt-in does to the sample, registered rather than discovered later:** an unpaid public recruit selects for people who already have feelings about work and technology. This is the central sampling property of the study, not a caveat. It is the reason the primary hypothesis is within-person, and the reason no estimate in any report will be framed as population prevalence.
-- **Expected attrition — and its direction:** unpaid daily participation loses people mid-week, and in a frustration study attrition is plausibly *caused by* the constructs under measurement — the missingness is likely informative (MNAR), biasing completer summaries in unknown direction. We register the expectation, report enrollment-vs-completion characteristics by exposure score, and do not impute.
+- **Expected attrition — and its direction:** unpaid daily participation loses people mid-week, and in a frustration study attrition is plausibly _caused by_ the constructs under measurement — the missingness is likely informative (MNAR), biasing completer summaries in unknown direction. We register the expectation, report enrollment-vs-completion characteristics by exposure score, and do not impute.
 - **Eligibility:** 18+, able to complete voice or SMS check-ins for ~a week, English for this pilot wave.
 - **Stopping rule:** recruitment closes at **90 enrolled participants or 6 weeks from launch, whichever comes first**, and is not reopened to chase a result. Analysis begins only after the final enrolled participant's 7-day window closes, and runs once.
 
@@ -96,7 +96,7 @@ Before registration of the final instrument wording, a pilot of **10–15 people
 - **Random slope:** we attempt `(1 + system_involved | participant)`; if it fails to converge or the slope variance is degenerate (likely at ~5–7 entries per person), we fall back to the random-intercept model. **This fallback is pre-declared here** so a convergence-driven model change cannot be a post-hoc choice.
 - **Reported:** fixed-effect odds ratio with 95% CI, judged against OR ≥ 1.5; ICC of the empty model; number of participants contributing within-person variance.
 - **Power gate:** only participants with at least one system-involved and one non-system entry inform the contrast. If fewer than **30 participants** have such variance, the primary analysis is reported as underpowered and descriptive only.
-- **Sensitivity checks (pre-declared):** (a) primary model on entries marked *just now / within the last hour* only; (b) primary model on a one-entry-per-day subsample (first entry per day); (c) primary model with time-of-day and recency as covariates.
+- **Sensitivity checks (pre-declared):** (a) primary model on entries marked _just now / within the last hour_ only; (b) primary model on a one-entry-per-day subsample (first entry per day); (c) primary model with time-of-day and recency as covariates.
 
 **Secondary (H2).** Within-person intensity contrast: multilevel linear model `intensity ~ system_involved + (1 | participant)`, same fallback logic, judged against the ≥ 0.5-point threshold.
 
@@ -104,7 +104,7 @@ Before registration of the final instrument wording, a pilot of **10–15 people
 
 **Descriptive.** Cohort-level tables of intensity and destination. If any inferential between-cohort test is reported at all it is labelled descriptive/secondary, uses the rules previously drafted (Kruskal–Wallis / χ² with the pre-declared `none/unclear` collapse for thin cells), and is gated: fewer than 15 completers per cohort ⇒ tables only, no tests.
 
-**Entry inclusion.** Entries marked *before today* are excluded from all confirmatory analyses and counted separately — same-day recall for salient discrete events is adequate for this design's claims; cross-day recall is not. No person-level exclusion applies to the primary model except the within-person-variance requirement above. "Completer" (≥ 3 check-in days) is a descriptive label and a gate for the secondary cohort analyses only.
+**Entry inclusion.** Entries marked _before today_ are excluded from all confirmatory analyses and counted separately — same-day recall for salient discrete events is adequate for this design's claims; cross-day recall is not. No person-level exclusion applies to the primary model except the within-person-variance requirement above. "Completer" (≥ 3 check-in days) is a descriptive label and a gate for the secondary cohort analyses only.
 
 **Coding.** As specified in Operational definitions: independent, blind, transcript-only, κ ≥ 0.70 on a 20% overlap sample, third-coder resolution, uncodable flagged not guessed.
 
@@ -117,7 +117,7 @@ Before registration of the final instrument wording, a pilot of **10–15 people
 ## Known limitations, registered in advance
 
 - **Self-selection is the central sampling property:** unpaid public opt-in selects for people who already feel something about the topic. Handled by making the primary hypothesis within-person; prevalence claims are out of scope entirely.
-- **Noticing bias:** participants report the moments they notice. If system-involved frustration is more *memorable* rather than more common or more displaced, the within-person contrast inherits that. This is a real, unremovable limitation of event-contingent sampling and we register it plainly.
+- **Noticing bias:** participants report the moments they notice. If system-involved frustration is more _memorable_ rather than more common or more displaced, the within-person contrast inherits that. This is a real, unremovable limitation of event-contingent sampling and we register it plainly.
 - **Moment-level confounding:** the within-person design absorbs stable confounds but not momentary ones — a system-involved moment may also be a busier moment. The design supports within-person association, not moment-level causation.
 - **Informative attrition:** dropout is plausibly correlated with the constructs under study; completer analyses are biased in unknown direction.
 - **Measurement reactivity:** a week of logging frustration may itself change frustration; reactivity in ESM is typically small but nonzero.

--- a/src/app/start/consent-gate.test.tsx
+++ b/src/app/start/consent-gate.test.tsx
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConsentGate } from "../../../components/ConsentGate";
+import { CONSENT_VERSION } from "@/content/consent";
+import { recordedEvents, resetTelemetry } from "@/lib/telemetry";
+
+/**
+ * SLICE-00-03 (issue #32) — the consent gate.
+ *
+ * The contract: consent is presented before any personal-data question,
+ * declining is as easy as accepting and ends the flow gracefully, the three
+ * agreements are independently refusable, and the decision carries the exact
+ * version shown.
+ */
+
+describe("SLICE-00-03 consent gate", () => {
+  const onDecision = vi.fn();
+
+  beforeEach(() => {
+    onDecision.mockReset();
+    resetTelemetry();
+    window.sessionStorage.clear();
+  });
+
+  const renderGate = () => render(<ConsentGate onDecision={onDecision} />);
+
+  const agreeToStudy = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(
+      screen.getByRole("checkbox", { name: /take part in this study/i }),
+    );
+    await user.click(screen.getByRole("checkbox", { name: /18 or older/i }));
+  };
+
+  describe("GIVEN a visitor arrives at the gate", () => {
+    it("THEN the consent content renders with no data-collecting inputs", () => {
+      renderGate();
+      // The gate asks for agreement, never for data: no free-text inputs.
+      expect(screen.queryAllByRole("textbox")).toHaveLength(0);
+      expect(screen.getByText(/this study is unpaid/i)).toBeInTheDocument();
+      expect(screen.getByText(/you can stop/i)).toBeInTheDocument();
+    });
+
+    it("THEN a draft version is visibly marked as not yet approved", () => {
+      renderGate();
+      if (CONSENT_VERSION.startsWith("draft")) {
+        expect(
+          screen.getByText(/draft.*not yet.*approved/i),
+        ).toBeInTheDocument();
+      }
+    });
+
+    it("THEN consentPresented fires once", () => {
+      renderGate();
+      const names = recordedEvents().map((e) => e.name);
+      expect(names).toEqual(["consentPresented"]);
+    });
+  });
+
+  describe("GIVEN the visitor declines", () => {
+    it("THEN declining is one click, needs no checkboxes, and reports declined", async () => {
+      const user = userEvent.setup();
+      renderGate();
+
+      await user.click(screen.getByRole("button", { name: /no thanks/i }));
+
+      expect(onDecision).toHaveBeenCalledWith({ declined: true });
+      expect(recordedEvents().some((e) => e.name === "consentDeclined")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("GIVEN the visitor accepts", () => {
+    it("THEN accepting requires the two required agreements", async () => {
+      const user = userEvent.setup();
+      renderGate();
+
+      const accept = screen.getByRole("button", { name: /i agree/i });
+      expect(accept).toBeDisabled();
+
+      await agreeToStudy(user);
+      expect(accept).toBeEnabled();
+    });
+
+    it("THEN the decision carries the exact consent version and the chosen scopes", async () => {
+      const user = userEvent.setup();
+      renderGate();
+
+      await agreeToStudy(user);
+      await user.click(
+        screen.getByRole("checkbox", { name: /text messages/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /i agree/i }));
+
+      expect(onDecision).toHaveBeenCalledWith({
+        declined: false,
+        consentVersion: CONSENT_VERSION,
+        scopes: { study: true, voice: false, sms: true },
+      });
+    });
+
+    it("THEN voice and SMS are independently refusable while study consent stands", async () => {
+      const user = userEvent.setup();
+      renderGate();
+
+      await agreeToStudy(user);
+      await user.click(screen.getByRole("button", { name: /i agree/i }));
+
+      expect(onDecision).toHaveBeenCalledWith({
+        declined: false,
+        consentVersion: CONSENT_VERSION,
+        scopes: { study: true, voice: false, sms: false },
+      });
+    });
+
+    it("THEN consentAccepted fires with the scopes and version, and no PII", async () => {
+      const user = userEvent.setup();
+      renderGate();
+
+      await agreeToStudy(user);
+      await user.click(
+        screen.getByRole("checkbox", { name: /voice check-ins/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /i agree/i }));
+
+      const accepted = recordedEvents().find(
+        (e) => e.name === "consentAccepted",
+      );
+      expect(accepted?.props).toEqual({
+        consent_version: CONSENT_VERSION,
+        biometric_scope: true,
+        sms_scope: false,
+      });
+    });
+  });
+});

--- a/src/app/start/page.tsx
+++ b/src/app/start/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import {
+  ConsentGate,
+  type ConsentDecision,
+} from "../../../components/ConsentGate";
+import { PageViewTracker } from "../../../components/PageViewTracker";
+
+/**
+ * /start — the entry to participation, SLICE-00-03 (issue #32).
+ *
+ * Consent comes before the screener by construction: the screener (EPIC-02)
+ * mounts behind this gate and cannot render without an accepting decision.
+ * Until the screener exists, acceptance lands on an honest holding state.
+ */
+export default function StartPage() {
+  const [decision, setDecision] = useState<ConsentDecision | null>(null);
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-6 py-16 md:py-24">
+      <PageViewTracker event="startPageViewed" />
+
+      {decision === null && <ConsentGate onDecision={setDecision} />}
+
+      {decision?.declined && (
+        <section>
+          <h1 className="font-display text-[clamp(2rem,5vw,3rem)] font-normal leading-[1.1]">
+            No problem.
+          </h1>
+          <p className="mt-6 text-[1.05rem] leading-[1.7]">
+            Nothing was collected — not your answer to this page, not anything.
+            The study will still publish everything it learns publicly, so you
+            can follow along without taking part.
+          </p>
+          <p className="mt-8">
+            <Link
+              href="/"
+              className="border-b border-rule pb-[0.15rem] font-data text-[0.63rem] uppercase tracking-[0.18em] text-ink-soft no-underline hover:border-accent hover:text-accent"
+            >
+              Back to the study
+            </Link>
+          </p>
+        </section>
+      )}
+
+      {decision && !decision.declined && (
+        <section>
+          <p className="font-data text-[0.6rem] uppercase tracking-[0.16em] text-ink-soft">
+            Consent recorded · {decision.consentVersion}
+          </p>
+          <h1 className="mt-4 font-display text-[clamp(2rem,5vw,3rem)] font-normal leading-[1.1]">
+            Thank you.
+          </h1>
+          <p className="mt-6 text-[1.05rem] leading-[1.7]">
+            The screener isn&rsquo;t open yet — the study doesn&rsquo;t collect
+            anything until its ethics review and registration are complete, and
+            we&rsquo;d rather be slow than casual about that. When it opens,
+            this page is where it starts.
+          </p>
+          <p className="mt-4 leading-[1.7] text-ink-soft">
+            Your consent choices are not stored anywhere yet either: enrollment
+            begins only when the study does.
+          </p>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/content/consent.ts
+++ b/src/content/consent.ts
@@ -1,0 +1,70 @@
+/**
+ * The consent content shown at the gate — SLICE-00-03 (issue #32).
+ *
+ * This is the web rendering of docs/compliance/informed-consent.md, kept in
+ * lockstep with it. The version string is stored on every consent decision
+ * and on every entry accepted under it, so it must change whenever this text
+ * changes meaning — never edit the words and keep the version.
+ *
+ * "draft-" versions render a visible not-yet-approved banner; the gate
+ * mechanism can be built and tested now, and counsel's edits later are a
+ * text change plus a version bump, not a rebuild.
+ */
+
+export const CONSENT_VERSION = "draft-0";
+
+export type ConsentSection = { heading: string; body: string[] };
+
+export const consentSections: ConsentSection[] = [
+  {
+    heading: "What this study is",
+    body: [
+      "We are studying what modern work does to mood, patience, and behavior — and where the frustration goes. We are not assuming a cause; we are looking for patterns.",
+      "If you join, you'll answer a short screener, send short check-ins for about a week (a text, or a voice note if you choose), and answer two brief surveys. Most days this is 5–10 minutes.",
+    ],
+  },
+  {
+    heading: "This is voluntary, and you can stop",
+    body: [
+      "You can skip a day, skip any question, or stop entirely, at any point, without telling us why. Nothing bad happens if you do.",
+      "This study is unpaid. There is no reward to lose, and we would rather say that plainly than imply otherwise. What you get is access to your own entries and patterns, and the findings we publish for everyone.",
+    ],
+  },
+  {
+    heading: "What we collect, and who sees it",
+    body: [
+      "Your screener and survey answers, your check-in entries, and contact details for sending prompts — stored separately from your answers.",
+      "Nobody at your job. We never contact employers, and nothing you say is shared with them. We publish patterns across all participants, never your raw entries, and never raw audio.",
+      "Please don't include your employer's name or anything that identifies your workplace. If you do by accident, tell us and we'll remove it.",
+    ],
+  },
+  {
+    heading: "If you choose voice",
+    body: [
+      "A recording of your voice can identify you the way a fingerprint can, so voice gets its own separate permission below — and you can complete the entire study by text with exactly the same standing.",
+      "Recordings are transcribed on our own computers. Your audio is never sent to an outside company, and we will never sell or profit from it.",
+    ],
+  },
+  {
+    heading: "The honest limits",
+    body: [
+      "We are researchers, not clinicians — this is not therapy or medical care, and it cannot respond to an emergency. If you are in crisis, call or text 988 (US), or 911 if someone is in immediate danger.",
+      "Thinking about frustrating parts of your day can itself be unpleasant. Any storage of personal information carries some breach risk, however carefully handled.",
+    ],
+  },
+  {
+    heading: "Your data, your call",
+    body: [
+      "Email bigmad@goodcitizens.us and ask, and we will delete your entries and contact details, then confirm. You don't need to give a reason.",
+    ],
+  },
+];
+
+export const agreements = {
+  study:
+    "I agree to take part in this study. I've read the above, I understand what I'd be doing, and I know I can stop at any time.",
+  age: "I am 18 or older.",
+  voice:
+    "I agree to record voice check-ins, and I specifically agree to Good Citizens collecting and storing a recording of my voice as described above. (Optional — you can complete the study without this.)",
+  sms: "I agree to receive text messages with check-in prompts. I understand these are recurring and I can reply STOP at any time. (Optional.)",
+} as const;

--- a/src/lib/checkin/store.test.ts
+++ b/src/lib/checkin/store.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import type { CheckInEntry, NewCheckIn } from "./types";
+import {
+  analysisEntries,
+  storeCheckIn,
+  type CheckInRepository,
+  type ConsentLookup,
+} from "./store";
+import type { ConsentRecord } from "@/lib/consent/types";
+
+/**
+ * SLICE-04-01 (issue #44) — entry schema & consent-linkage guard.
+ *
+ * The two structural promises: nothing is stored without a linkable consent
+ * record of the required scopes, and pilot data can never reach an analysis
+ * query. Both are the kind of guarantee that must be proven by a failing
+ * test, not read off the code.
+ */
+
+const CONSENT: ConsentRecord = {
+  hashedParticipantId: "hp_abc",
+  consentVersion: "draft-0",
+  scopes: { study: true, voice: false, sms: true },
+  agreedAt: "2026-08-01T00:00:00Z",
+};
+
+const smsEntry = (overrides: Partial<NewCheckIn> = {}): NewCheckIn => ({
+  hashedParticipantId: "hp_abc",
+  channel: "sms",
+  narrative: "the routing app rerouted me twice",
+  destination: "tool",
+  intensity: 7,
+  recency: "just_now",
+  pilot: false,
+  ...overrides,
+});
+
+function harness(consents: ConsentRecord[] = [CONSENT]) {
+  const stored: CheckInEntry[] = [];
+  const refusals: { reason: string }[] = [];
+  const repo: CheckInRepository = {
+    persist: async (entry) => {
+      stored.push(entry);
+      return entry;
+    },
+    all: async () => stored,
+  };
+  const lookup: ConsentLookup = async (id) =>
+    consents.find((c) => c.hashedParticipantId === id) ?? null;
+  return {
+    repo,
+    lookup,
+    stored,
+    refusals,
+    logRefusal: (reason: string) => refusals.push({ reason }),
+  };
+}
+
+describe("SLICE-04-01 check-in storage", () => {
+  // ── Zero: everything optional skipped ────────────────────────────────────
+  it("stores an entry with every optional field skipped", async () => {
+    const h = harness();
+    const result = await storeCheckIn(
+      smsEntry({
+        destination: "skipped",
+        intensity: "skipped",
+        recency: "skipped",
+      }),
+      h.repo,
+      h.lookup,
+      h.logRefusal,
+    );
+
+    expect(result.stored).toBe(true);
+    expect(h.stored[0].destination).toBe("skipped");
+    expect(h.stored[0].intensity).toBe("skipped");
+    expect(h.stored[0].recency).toBe("skipped");
+  });
+
+  // ── One / Simple ─────────────────────────────────────────────────────────
+  it("round-trips a full entry with all fields typed and the consent version stamped", async () => {
+    const h = harness();
+    await storeCheckIn(smsEntry(), h.repo, h.lookup, h.logRefusal);
+
+    expect(h.stored).toHaveLength(1);
+    const entry = h.stored[0];
+    expect(entry.destination).toBe("tool");
+    expect(entry.intensity).toBe(7);
+    expect(entry.recency).toBe("just_now");
+    expect(entry.consentVersion).toBe("draft-0");
+    expect(entry.receivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  // ── Exception: the consent guard ─────────────────────────────────────────
+  describe("consent-linkage guard", () => {
+    it("refuses an entry with no linkable consent record", async () => {
+      const h = harness([]);
+      const result = await storeCheckIn(
+        smsEntry(),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(result.stored).toBe(false);
+      expect(h.stored).toHaveLength(0);
+      expect(h.refusals).toHaveLength(1);
+      expect(h.refusals[0].reason).toBe("no_consent_record");
+    });
+
+    it("refuses a voice entry when the biometric scope is missing", async () => {
+      const h = harness(); // CONSENT has voice: false
+      const result = await storeCheckIn(
+        smsEntry({ channel: "voice" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(result.stored).toBe(false);
+      expect(h.refusals[0].reason).toBe("missing_scope_voice");
+    });
+
+    it("refuses when study consent itself is revoked", async () => {
+      const h = harness([
+        { ...CONSENT, scopes: { ...CONSENT.scopes, study: false } },
+      ]);
+      const result = await storeCheckIn(
+        smsEntry(),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(result.stored).toBe(false);
+      expect(h.refusals[0].reason).toBe("missing_scope_study");
+    });
+
+    it("logs the refusal without the entry content", async () => {
+      const h = harness([]);
+      await storeCheckIn(
+        smsEntry({ narrative: "something deeply personal" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(JSON.stringify(h.refusals)).not.toContain("deeply personal");
+    });
+  });
+
+  // ── Boundary: intensity edges ────────────────────────────────────────────
+  it.each([0, 10])(
+    "accepts intensity %i at the boundary",
+    async (intensity) => {
+      const h = harness();
+      const result = await storeCheckIn(
+        smsEntry({ intensity }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      expect(result.stored).toBe(true);
+    },
+  );
+
+  it("rejects an out-of-range intensity rather than clamping it", async () => {
+    const h = harness();
+    const result = await storeCheckIn(
+      smsEntry({ intensity: 11 as never }),
+      h.repo,
+      h.lookup,
+      h.logRefusal,
+    );
+    expect(result.stored).toBe(false);
+    expect(h.refusals[0].reason).toBe("invalid_intensity");
+  });
+
+  // ── Interface / Many: pilot separation ───────────────────────────────────
+  describe("pilot separation", () => {
+    it("excludes pilot rows from analysis queries by construction", async () => {
+      const h = harness();
+      await storeCheckIn(
+        smsEntry({ pilot: true, narrative: "pilot one" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      await storeCheckIn(
+        smsEntry({ narrative: "study one" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      await storeCheckIn(
+        smsEntry({ pilot: true, narrative: "pilot two" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      const analysable = await analysisEntries(h.repo);
+
+      expect(analysable).toHaveLength(1);
+      expect(analysable[0].narrative).toBe("study one");
+    });
+
+    it("marks pilot on the stored entry immutably at ingest", async () => {
+      const h = harness();
+      await storeCheckIn(
+        smsEntry({ pilot: true }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      expect(h.stored[0].pilot).toBe(true);
+    });
+  });
+});

--- a/src/lib/checkin/store.ts
+++ b/src/lib/checkin/store.ts
@@ -1,0 +1,81 @@
+import type { ConsentRecord } from "@/lib/consent/types";
+import type { Channel, CheckInEntry, NewCheckIn } from "./types";
+
+/**
+ * Check-in storage with the consent-linkage guard — SLICE-04-01 (issue #44).
+ *
+ * Collection without consent must be impossible, not discouraged, so the
+ * guard lives in the one function every channel must pass through rather
+ * than in each channel's good intentions. Refusals are logged by reason
+ * only — a refused entry's content is exactly the thing we had no right
+ * to keep.
+ */
+
+export type CheckInRepository = {
+  persist(entry: CheckInEntry): Promise<CheckInEntry>;
+  all(): Promise<readonly CheckInEntry[]>;
+};
+
+export type ConsentLookup = (
+  hashedParticipantId: string,
+) => Promise<ConsentRecord | null>;
+
+export type RefusalLog = (reason: string) => void;
+
+export type StoreResult =
+  | { stored: true; entry: CheckInEntry }
+  | { stored: false; reason: string };
+
+const SCOPE_FOR_CHANNEL: Record<Channel, "voice" | null> = {
+  sms: null, // receiving an SMS needs study consent only; sending needs sms scope (#35, #49)
+  voice: "voice",
+};
+
+function invalidIntensity(intensity: NewCheckIn["intensity"]): boolean {
+  if (intensity === "skipped") return false;
+  return !Number.isInteger(intensity) || intensity < 0 || intensity > 10;
+}
+
+export async function storeCheckIn(
+  incoming: NewCheckIn,
+  repo: CheckInRepository,
+  findConsent: ConsentLookup,
+  logRefusal: RefusalLog,
+): Promise<StoreResult> {
+  const refuse = (reason: string): StoreResult => {
+    logRefusal(reason);
+    return { stored: false, reason };
+  };
+
+  const consent = await findConsent(incoming.hashedParticipantId);
+  if (!consent) return refuse("no_consent_record");
+  if (!consent.scopes.study) return refuse("missing_scope_study");
+
+  const channelScope = SCOPE_FOR_CHANNEL[incoming.channel];
+  if (channelScope && !consent.scopes[channelScope]) {
+    return refuse(`missing_scope_${channelScope}`);
+  }
+
+  if (invalidIntensity(incoming.intensity)) return refuse("invalid_intensity");
+
+  const entry: CheckInEntry = Object.freeze({
+    ...incoming,
+    receivedAt: new Date().toISOString(),
+    consentVersion: consent.consentVersion,
+  });
+
+  await repo.persist(entry);
+  return { stored: true, entry };
+}
+
+/**
+ * The only sanctioned read path for analysis. Pilot rows are excluded here,
+ * by construction — an analysis that wants pilot data has to go around this
+ * function, and doing so is the defect the tests exist to catch.
+ */
+export async function analysisEntries(
+  repo: CheckInRepository,
+): Promise<readonly CheckInEntry[]> {
+  const entries = await repo.all();
+  return entries.filter((entry) => !entry.pilot);
+}

--- a/src/lib/checkin/types.ts
+++ b/src/lib/checkin/types.ts
@@ -1,0 +1,53 @@
+/**
+ * The check-in entry — SLICE-04-01 (issue #44).
+ *
+ * Field names mirror the pre-registration's Operational definitions verbatim
+ * (docs/compliance/pre-registration.md). The registration is the spec; the
+ * code follows it, and changes to the instrument go through the registration
+ * first.
+ *
+ * Skips are first-class values, not nulls: the landing page promises any
+ * question can be skipped, and a skipped answer is data (it is counted),
+ * where a null is an accident.
+ */
+
+export type Destination =
+  | "tool"
+  | "other_people"
+  | "myself"
+  | "nowhere"
+  /** Pilot-only fifth option; frozen out or in by SLICE-04-03. */
+  | { other: string }
+  | "skipped";
+
+export type Recency =
+  | "just_now"
+  | "within_hour"
+  | "earlier_today"
+  | "before_today"
+  | "skipped";
+
+export type Intensity = number | "skipped"; // 0–10 integer when present
+
+export type Channel = "sms" | "voice";
+
+/** What a channel hands to storage. */
+export type NewCheckIn = {
+  hashedParticipantId: string;
+  channel: Channel;
+  narrative: string;
+  destination: Destination;
+  intensity: Intensity;
+  recency: Recency;
+  /** Immutable at ingest — pilot data must never mix with study data. */
+  pilot: boolean;
+};
+
+/** What storage persists: the entry plus what only storage may stamp. */
+export type CheckInEntry = Readonly<
+  NewCheckIn & {
+    receivedAt: string;
+    /** The consent text version in force when this entry was accepted. */
+    consentVersion: string;
+  }
+>;

--- a/src/lib/consent/types.ts
+++ b/src/lib/consent/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Consent records — shared between the screener gate (SLICE-00-03, #32) and
+ * check-in storage (SLICE-04-01, #44).
+ *
+ * The three scopes mirror the consent document's three separately-refusable
+ * agreements. Bundled consent is not consent, so they are independent
+ * booleans rather than a single flag.
+ */
+
+export type ConsentScopes = {
+  /** The study itself. Required — without it nothing may be stored. */
+  study: boolean;
+  /** Biometric consent for voice recordings (BIPA-grade, separate). */
+  voice: boolean;
+  /** TCPA consent to receive recurring SMS prompts. */
+  sms: boolean;
+};
+
+export type ConsentRecord = {
+  hashedParticipantId: string;
+  /** Which text they agreed to — the exact version shown, never inferred. */
+  consentVersion: string;
+  scopes: ConsentScopes;
+  agreedAt: string;
+};


### PR DESCRIPTION
Closes #32. Parent EPIC: #30. **Stacked on #50** — uses its `ConsentScopes` type; retarget to the staging branch when #50 merges.

The consent gate the screener will mount behind, and the repair of the landing page's primary CTA (`/start` had 404'd since #27's copy shipped).

**The contract, each encoded as a test:** the gate collects agreement, never data (zero text inputs, asserted) · the three agreements are independently refusable · accept requires study + age; decline requires nothing — declining must never be harder than accepting · the decision carries the exact version shown and the exact scopes granted · `draft-*` versions render a visible not-yet-approved banner.

**Honest states:** declining lands on "nothing was collected" (true — no persistence exists). Accepting lands on "the screener isn't open yet" with the reason. Consent decisions are not yet stored; the page says so rather than implying enrollment.

**Verification:** 8 new tests red-first; 96 unit tests total; lint/typecheck/build green.

**Accepted residuals:** decisions not persisted by design until enrollment opens (disclosed on the page). Consent text is `draft-0` pending counsel — a text change plus version bump. `startPageViewed` added to telemetry.