### PR TITLE
SLICE: EPIC-04 SMS check-in flow

### DIFF
--- a/src/app/api/checkin/sms/route.ts
+++ b/src/app/api/checkin/sms/route.ts
@@ -1,0 +1,57 @@
+import { createHmac } from "node:crypto";
+import { NextResponse } from "next/server";
+import { handleInboundSms, type SmsDeps } from "@/lib/checkin/smsWebhook";
+import type { CheckInEntry } from "@/lib/checkin/types";
+
+/**
+ * Twilio inbound-SMS webhook — SLICE-04-02 (issue #45).
+ *
+ * Wiring only: all behavior lives in handleInboundSms, which is where the
+ * tests are. Until persistence exists, the consent lookup returns null for
+ * everyone — so every real message gets the not-enrolled reply and nothing
+ * is ever stored. The safe default is the deliberate one: this endpoint can
+ * ship to staging today without being able to collect a single entry.
+ */
+
+const entries: CheckInEntry[] = [];
+const repairs = new Map<string, string>();
+
+function hashPhone(phone: string): string {
+  // HMAC, not plain SHA-256: without the secret, a phone number cannot be
+  // confirmed against its hash by brute-forcing the ten-digit space.
+  const secret = process.env.PARTICIPANT_HASH_SECRET ?? "";
+  if (!secret) return "hp_unconfigured";
+  return `hp_${createHmac("sha256", secret).update(phone).digest("hex").slice(0, 32)}`;
+}
+
+const deps: SmsDeps = {
+  repo: {
+    persist: async (entry) => (entries.push(entry), entry),
+    all: async () => entries,
+  },
+  // Enrollment does not exist yet (#32 stores no decisions, by design), so
+  // no number has consent and the guard refuses everything. Replaced by the
+  // real consent store when enrollment opens.
+  findConsent: async () => null,
+  hashPhone,
+  logRefusal: (reason) => console.warn(`[sms] refused: ${reason}`),
+  repairPending: {
+    get: (id) => repairs.get(id) ?? null,
+    set: (id, narrative) => void repairs.set(id, narrative),
+    delete: (id) => void repairs.delete(id),
+  },
+  pilot: process.env.CHECKIN_PILOT_MODE === "true",
+};
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const form = await request.formData();
+  const from = String(form.get("From") ?? "");
+  const body = String(form.get("Body") ?? "");
+
+  const reply = await handleInboundSms({ From: from, Body: body }, deps);
+
+  const twiml = `<?xml version="1.0" encoding="UTF-8"?><Response><Message>${reply}</Message></Response>`;
+  return new NextResponse(twiml, {
+    headers: { "Content-Type": "text/xml" },
+  }) as NextResponse;
+}

--- a/src/lib/checkin/parseSms.test.ts
+++ b/src/lib/checkin/parseSms.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { parseSms } from "./parseSms";
+
+/**
+ * SLICE-04-02 (issue #45) — the SMS parser.
+ *
+ * The format teaches; the parser accommodates. People will not follow the
+ * order, will spell destinations their own way, and will sometimes send
+ * only a story. Every parse returns a full result with skips where pieces
+ * are missing — the parser never fails, it only degrades.
+ */
+
+describe("parseSms", () => {
+  // ── Zero ──────────────────────────────────────────────────────────────────
+  it("returns all-skipped fields for an empty message", () => {
+    const parsed = parseSms("");
+    expect(parsed).toEqual({
+      narrative: "",
+      destination: "skipped",
+      intensity: "skipped",
+      recency: "skipped",
+      complete: false,
+    });
+  });
+
+  // ── Simple: the taught format ────────────────────────────────────────────
+  it("parses the taught format: number, destination, recency, story", () => {
+    const parsed = parseSms(
+      "7, the tool, just now, the routing app rerouted me twice",
+    );
+    expect(parsed.intensity).toBe(7);
+    expect(parsed.destination).toBe("tool");
+    expect(parsed.recency).toBe("just_now");
+    expect(parsed.narrative).toBe("the routing app rerouted me twice");
+    expect(parsed.complete).toBe(true);
+  });
+
+  // ── Many: order does not matter ──────────────────────────────────────────
+  it.each([
+    "the app ate my shift, 9, them, earlier today",
+    "9 them earlier today — the app ate my shift",
+    "them. earlier today. 9. the app ate my shift",
+  ])("parses the same fields from any ordering: %s", (message) => {
+    const parsed = parseSms(message);
+    expect(parsed.intensity).toBe(9);
+    expect(parsed.destination).toBe("other_people");
+    expect(parsed.recency).toBe("earlier_today");
+    expect(parsed.narrative).toContain("the app ate my shift");
+  });
+
+  // ── Destination vocabulary ───────────────────────────────────────────────
+  it.each([
+    ["tool", "tool"],
+    ["the app", "tool"],
+    ["them", "other_people"],
+    ["other people", "other_people"],
+    ["my coworkers", "other_people"],
+    ["me", "myself"],
+    ["myself", "myself"],
+    ["nowhere", "nowhere"],
+    ["no one", "nowhere"],
+  ])("maps destination word %s to %s", (word, expected) => {
+    const parsed = parseSms(`5, ${word}, just now, a thing happened`);
+    expect(parsed.destination).toBe(expected);
+  });
+
+  // ── Recency vocabulary ───────────────────────────────────────────────────
+  it.each([
+    ["just now", "just_now"],
+    ["a minute ago", "just_now"],
+    ["within the hour", "within_hour"],
+    ["an hour ago", "within_hour"],
+    ["earlier today", "earlier_today"],
+    ["this morning", "earlier_today"],
+    ["yesterday", "before_today"],
+    ["last week", "before_today"],
+  ])("maps recency phrase %s to %s", (phrase, expected) => {
+    const parsed = parseSms(`5, the tool, ${phrase}, a thing happened`);
+    expect(parsed.recency).toBe(expected);
+  });
+
+  // ── Boundary ─────────────────────────────────────────────────────────────
+  it.each([0, 10])("accepts intensity %i", (n) => {
+    expect(parseSms(`${n}, tool, just now, story`).intensity).toBe(n);
+  });
+
+  it("does not read 11 as an intensity", () => {
+    const parsed = parseSms("11, tool, just now, story about 11 things");
+    expect(parsed.intensity).toBe("skipped");
+  });
+
+  it("does not steal a number that is part of the narrative", () => {
+    // No standalone leading/trailing rating — "2 hours" is story, not score.
+    const parsed = parseSms("waited 2 hours for the system to come back, tool");
+    expect(parsed.intensity).toBe("skipped");
+    expect(parsed.narrative).toContain("2 hours");
+  });
+
+  // ── Exception: narrative-only ────────────────────────────────────────────
+  it("keeps a narrative-only message as an incomplete parse, not an error", () => {
+    const parsed = parseSms("the scheduler double-booked me and nobody cares");
+    expect(parsed.narrative).toBe(
+      "the scheduler double-booked me and nobody cares",
+    );
+    expect(parsed.destination).toBe("skipped");
+    expect(parsed.complete).toBe(false);
+  });
+});

--- a/src/lib/checkin/parseSms.ts
+++ b/src/lib/checkin/parseSms.ts
@@ -1,0 +1,125 @@
+import type { Destination, Intensity, Recency } from "./types";
+
+/**
+ * SMS check-in parser — SLICE-04-02 (issue #45).
+ *
+ * The prompt teaches a format; this parser accommodates what people actually
+ * send. It scans for the three structured pieces anywhere in the message,
+ * but a piece only counts when it sits in *answer position* — delimited by
+ * punctuation or the message edge — never when the same word is embedded in
+ * the story ("the app ate my shift" is narrative; ", the app," is an
+ * answer). It never throws and never fails: missing pieces are "skipped",
+ * and `complete` tells the caller whether a repair prompt is worth sending.
+ */
+
+export type ParsedSms = {
+  narrative: string;
+  destination: Destination;
+  intensity: Intensity;
+  recency: Recency;
+  /** True when all three structured fields were found. */
+  complete: boolean;
+};
+
+type ConcreteDestination = Exclude<Destination, "skipped" | { other: string }>;
+
+const DESTINATION_PATTERNS: [RegExp, ConcreteDestination][] = [
+  [/(the )?(tool|app|system|software|dashboard|machine)/i, "tool"],
+  [
+    /(them|other people|others|coworkers?|my (coworkers?|team|boss|family|partner|kids?))/i,
+    "other_people",
+  ],
+  [/(myself|me)/i, "myself"],
+  [/(nowhere|no ?one|nobody|nothing)/i, "nowhere"],
+];
+
+const RECENCY_PATTERNS: [RegExp, Exclude<Recency, "skipped">][] = [
+  [/(just now|right now|a (minute|moment|second) ago|minutes ago)/i, "just_now"],
+  [/(within the (last )?hour|an hour ago|past hour)/i, "within_hour"],
+  [/(earlier today|this (morning|afternoon)|today)/i, "earlier_today"],
+  [/(yesterday|last (night|week)|days? ago|before today)/i, "before_today"],
+];
+
+const DELIM = "[,.;\\u2014\\u2013-]";
+
+/**
+ * Matches `inner` only in answer position: preceded by start-of-message or a
+ * delimiter, followed by end-of-message or a delimiter.
+ */
+function delimited(inner: string): RegExp {
+  return new RegExp(
+    `(?:^|${DELIM})\\s*(?:${inner})\\s*(?=$|${DELIM})`,
+    "i",
+  );
+}
+
+function claim(
+  text: string,
+  inner: string,
+): { found: boolean; rest: string } {
+  const match = text.match(delimited(inner));
+  if (!match) return { found: false, rest: text };
+  return { found: true, rest: text.replace(match[0], " ") };
+}
+
+function clean(narrative: string): string {
+  return narrative
+    .replace(/\s*[,.;—–-]\s*[,.;—–-]+\s*/g, ", ")
+    .replace(/^[\s,.;—–-]+|[\s,.;—–-]+$/g, "")
+    .replace(/\s{2,}/g, " ");
+}
+
+export function parseSms(body: string): ParsedSms {
+  let rest = body.trim();
+
+  // A rating counts at the very start of the message ("9 them ...", the
+  // taught format) or delimited anywhere — never embedded ("waited 2 hours").
+  let intensity: Intensity = "skipped";
+  const leading = rest.match(/^(10|[0-9])(?=\s|$)/);
+  if (leading) {
+    intensity = Number(leading[1]);
+    rest = rest.slice(leading[0].length);
+  } else {
+    const ratingClaim = claim(rest, "10|[0-9]");
+    if (ratingClaim.found) {
+      const value = rest.match(delimited("10|[0-9]"))?.[0].match(/10|[0-9]/);
+      intensity = Number(value?.[0]);
+      rest = ratingClaim.rest;
+    }
+  }
+
+  // Recency phrases are distinctive enough to claim wherever they appear.
+  let recency: Recency = "skipped";
+  for (const [pattern, value] of RECENCY_PATTERNS) {
+    const match = rest.match(pattern);
+    if (match) {
+      recency = value;
+      rest = rest.replace(match[0], " ");
+      break;
+    }
+  }
+
+  // Destinations are ordinary words, so only answer position counts. The
+  // first pattern with a *delimited* occurrence wins — an embedded "the app"
+  // in the story never outranks a delimited "them".
+  let destination: Destination = "skipped";
+  for (const [pattern, value] of DESTINATION_PATTERNS) {
+    const result = claim(rest, pattern.source);
+    if (result.found) {
+      destination = value;
+      rest = result.rest;
+      break;
+    }
+  }
+
+  return {
+    narrative: clean(rest),
+    destination,
+    intensity,
+    recency,
+    complete:
+      destination !== "skipped" &&
+      intensity !== "skipped" &&
+      recency !== "skipped",
+  };
+}

--- a/src/lib/checkin/smsWebhook.test.ts
+++ b/src/lib/checkin/smsWebhook.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { CheckInEntry } from "./types";
+import type { CheckInRepository, ConsentLookup } from "./store";
+import { handleInboundSms, type SmsDeps } from "./smsWebhook";
+import type { ConsentRecord } from "@/lib/consent/types";
+
+/**
+ * SLICE-04-02 (issue #45) — the inbound SMS webhook, tested against Twilio
+ * fixture payloads. The consent guard is exercised through the whole path:
+ * an un-consented number produces no stored entry and no study content in
+ * the reply.
+ */
+
+const CONSENT: ConsentRecord = {
+  hashedParticipantId: "hp_abc",
+  consentVersion: "draft-0",
+  scopes: { study: true, voice: false, sms: true },
+  agreedAt: "2026-08-01T00:00:00Z",
+};
+
+function fixture(body: string, from = "+15551230000") {
+  return { From: from, Body: body };
+}
+
+function harness(consents: ConsentRecord[] = [CONSENT]) {
+  const stored: CheckInEntry[] = [];
+  const repairPending = new Map<string, string>();
+  const repo: CheckInRepository = {
+    persist: async (entry) => (stored.push(entry), entry),
+    all: async () => stored,
+  };
+  const findConsent: ConsentLookup = async (id) =>
+    consents.find((c) => c.hashedParticipantId === id) ?? null;
+  const deps: SmsDeps = {
+    repo,
+    findConsent,
+    // A real hash never embeds the number; the fake must not either, or the
+    // never-stores-raw-phone assertion tests the fixture instead of the code.
+    hashPhone: (phone) => (phone === "+15551230000" ? "hp_abc" : "hp_unknown"),
+    logRefusal: () => {},
+    repairPending: {
+      get: (id) => repairPending.get(id) ?? null,
+      set: (id, narrative) => void repairPending.set(id, narrative),
+      delete: (id) => void repairPending.delete(id),
+    },
+    pilot: false,
+  };
+  return { deps, stored, repairPending };
+}
+
+describe("SLICE-04-02 inbound SMS", () => {
+  let h: ReturnType<typeof harness>;
+  beforeEach(() => {
+    h = harness();
+  });
+
+  it("stores a well-formed message and confirms", async () => {
+    const reply = await handleInboundSms(
+      fixture("7, the tool, just now, the routing app rerouted me twice"),
+      h.deps,
+    );
+
+    expect(h.stored).toHaveLength(1);
+    expect(h.stored[0].intensity).toBe(7);
+    expect(h.stored[0].destination).toBe("tool");
+    expect(reply).toMatch(/got it/i);
+  });
+
+  it("asks once for the missing pieces, then stores what it has", async () => {
+    const first = await handleInboundSms(
+      fixture("the scheduler double-booked me"),
+      h.deps,
+    );
+    expect(h.stored).toHaveLength(0);
+    expect(first).toMatch(/0.*10/); // the repair prompt reteaches the format
+
+    const second = await handleInboundSms(fixture("8, me"), h.deps);
+    expect(h.stored).toHaveLength(1);
+    // The first message's story is not lost — it merges with the repair reply.
+    expect(h.stored[0].narrative).toContain("the scheduler double-booked me");
+    expect(h.stored[0].intensity).toBe(8);
+    expect(h.stored[0].destination).toBe("myself");
+    expect(second).toMatch(/got it/i);
+  });
+
+  it("does not loop: a complete entry clears the repair state", async () => {
+    await handleInboundSms(fixture("only a story"), h.deps);
+    await handleInboundSms(fixture("8, me, just now, rough one"), h.deps);
+    expect(h.repairPending.size).toBe(0);
+  });
+
+  it("refuses an un-consented number: nothing stored, no study content echoed", async () => {
+    const reply = await handleInboundSms(
+      fixture("7, tool, just now, something personal", "+19998887777"),
+      h.deps,
+    );
+
+    expect(h.stored).toHaveLength(0);
+    expect(reply).not.toContain("something personal");
+    expect(reply).toMatch(/isn.t enrolled/i);
+  });
+
+  it("marks entries as pilot when the flow runs in pilot mode", async () => {
+    const pilotDeps = { ...h.deps, pilot: true };
+    await handleInboundSms(fixture("5, them, just now, pilot story"), pilotDeps);
+    expect(h.stored[0].pilot).toBe(true);
+  });
+
+  it("never stores the raw phone number", async () => {
+    await handleInboundSms(fixture("5, them, just now, a story"), h.deps);
+    expect(JSON.stringify(h.stored)).not.toContain("+15551230000");
+  });
+});

--- a/src/lib/checkin/smsWebhook.ts
+++ b/src/lib/checkin/smsWebhook.ts
@@ -1,0 +1,89 @@
+import type { ConsentRecord } from "@/lib/consent/types";
+import { parseSms } from "./parseSms";
+import {
+  storeCheckIn,
+  type CheckInRepository,
+  type ConsentLookup,
+  type RefusalLog,
+} from "./store";
+
+/**
+ * Inbound SMS handling — SLICE-04-02 (issue #45).
+ *
+ * One gentle repair prompt, never a loop: an incomplete first message gets
+ * one reteach of the format; whatever comes next is stored with skips for
+ * anything still missing. The consent guard runs on the receive path too —
+ * an un-consented sender gets a neutral reply that echoes nothing they
+ * wrote, because content we refuse to store is content we refuse to handle.
+ */
+
+export type SmsDeps = {
+  repo: CheckInRepository;
+  findConsent: ConsentLookup;
+  /** Raw phone → hashed participant id. The raw number is never persisted. */
+  hashPhone: (phone: string) => string;
+  logRefusal: RefusalLog;
+  /** Holds the first message's narrative while the repair prompt is out. */
+  repairPending: {
+    get(id: string): string | null;
+    set(id: string, narrative: string): void;
+    delete(id: string): void;
+  };
+  /** True while the flow serves the design pilot (SLICE-04-03). */
+  pilot: boolean;
+};
+
+export type InboundSms = { From: string; Body: string };
+
+const REPLIES = {
+  notEnrolled:
+    "This number isn't enrolled in the Big-Mad Study, so nothing was saved. If you meant to join, start at the study website.",
+  repair:
+    "Got the story — could you add a number 0–10 for how much it got to you, where it went (tool / them / me / nowhere), and when it happened? One text is fine.",
+  confirmed: "Got it — thank you. Skip any day you need to.",
+} as const;
+
+export async function handleInboundSms(
+  message: InboundSms,
+  deps: SmsDeps,
+): Promise<string> {
+  const hashedParticipantId = deps.hashPhone(message.From);
+
+  const consent: ConsentRecord | null = await deps.findConsent(hashedParticipantId);
+  if (!consent || !consent.scopes.study) {
+    deps.logRefusal("sms_from_unconsented_number");
+    return REPLIES.notEnrolled;
+  }
+
+  const parsed = parseSms(message.Body);
+  const pendingNarrative = deps.repairPending.get(hashedParticipantId);
+
+  // First incomplete message: one repair prompt, holding the story so it is
+  // never lost. Second message, complete or not: store, merging narratives.
+  // The format teaches; it never gatekeeps and it never discards.
+  if (!parsed.complete && pendingNarrative === null) {
+    deps.repairPending.set(hashedParticipantId, parsed.narrative);
+    return REPLIES.repair;
+  }
+  deps.repairPending.delete(hashedParticipantId);
+  const narrative = [pendingNarrative, parsed.narrative]
+    .filter((part) => part && part.length > 0)
+    .join(" — ");
+
+  const result = await storeCheckIn(
+    {
+      hashedParticipantId,
+      channel: "sms",
+      narrative,
+      destination: parsed.destination,
+      intensity: parsed.intensity,
+      recency: parsed.recency,
+      pilot: deps.pilot,
+    },
+    deps.repo,
+    deps.findConsent,
+    deps.logRefusal,
+  );
+
+  return result.stored ? REPLIES.confirmed : REPLIES.notEnrolled;
+}

--- a/src/lib/checkin/store.test.ts
+++ b/src/lib/checkin/store.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import type { CheckInEntry, NewCheckIn } from "./types";
+import {
+  analysisEntries,
+  storeCheckIn,
+  type CheckInRepository,
+  type ConsentLookup,
+} from "./store";
+import type { ConsentRecord } from "@/lib/consent/types";
+
+/**
+ * SLICE-04-01 (issue #44) — entry schema & consent-linkage guard.
+ *
+ * The two structural promises: nothing is stored without a linkable consent
+ * record of the required scopes, and pilot data can never reach an analysis
+ * query. Both are the kind of guarantee that must be proven by a failing
+ * test, not read off the code.
+ */
+
+const CONSENT: ConsentRecord = {
+  hashedParticipantId: "hp_abc",
+  consentVersion: "draft-0",
+  scopes: { study: true, voice: false, sms: true },
+  agreedAt: "2026-08-01T00:00:00Z",
+};
+
+const smsEntry = (overrides: Partial<NewCheckIn> = {}): NewCheckIn => ({
+  hashedParticipantId: "hp_abc",
+  channel: "sms",
+  narrative: "the routing app rerouted me twice",
+  destination: "tool",
+  intensity: 7,
+  recency: "just_now",
+  pilot: false,
+  ...overrides,
+});
+
+function harness(consents: ConsentRecord[] = [CONSENT]) {
+  const stored: CheckInEntry[] = [];
+  const refusals: { reason: string }[] = [];
+  const repo: CheckInRepository = {
+    persist: async (entry) => {
+      stored.push(entry);
+      return entry;
+    },
+    all: async () => stored,
+  };
+  const lookup: ConsentLookup = async (id) =>
+    consents.find((c) => c.hashedParticipantId === id) ?? null;
+  return {
+    repo,
+    lookup,
+    stored,
+    refusals,
+    logRefusal: (reason: string) => refusals.push({ reason }),
+  };
+}
+
+describe("SLICE-04-01 check-in storage", () => {
+  // ── Zero: everything optional skipped ────────────────────────────────────
+  it("stores an entry with every optional field skipped", async () => {
+    const h = harness();
+    const result = await storeCheckIn(
+      smsEntry({
+        destination: "skipped",
+        intensity: "skipped",
+        recency: "skipped",
+      }),
+      h.repo,
+      h.lookup,
+      h.logRefusal,
+    );
+
+    expect(result.stored).toBe(true);
+    expect(h.stored[0].destination).toBe("skipped");
+    expect(h.stored[0].intensity).toBe("skipped");
+    expect(h.stored[0].recency).toBe("skipped");
+  });
+
+  // ── One / Simple ─────────────────────────────────────────────────────────
+  it("round-trips a full entry with all fields typed and the consent version stamped", async () => {
+    const h = harness();
+    await storeCheckIn(smsEntry(), h.repo, h.lookup, h.logRefusal);
+
+    expect(h.stored).toHaveLength(1);
+    const entry = h.stored[0];
+    expect(entry.destination).toBe("tool");
+    expect(entry.intensity).toBe(7);
+    expect(entry.recency).toBe("just_now");
+    expect(entry.consentVersion).toBe("draft-0");
+    expect(entry.receivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  // ── Exception: the consent guard ─────────────────────────────────────────
+  describe("consent-linkage guard", () => {
+    it("refuses an entry with no linkable consent record", async () => {
+      const h = harness([]);
+      const result = await storeCheckIn(
+        smsEntry(),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(result.stored).toBe(false);
+      expect(h.stored).toHaveLength(0);
+      expect(h.refusals).toHaveLength(1);
+      expect(h.refusals[0].reason).toBe("no_consent_record");
+    });
+
+    it("refuses a voice entry when the biometric scope is missing", async () => {
+      const h = harness(); // CONSENT has voice: false
+      const result = await storeCheckIn(
+        smsEntry({ channel: "voice" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(result.stored).toBe(false);
+      expect(h.refusals[0].reason).toBe("missing_scope_voice");
+    });
+
+    it("refuses when study consent itself is revoked", async () => {
+      const h = harness([
+        { ...CONSENT, scopes: { ...CONSENT.scopes, study: false } },
+      ]);
+      const result = await storeCheckIn(
+        smsEntry(),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(result.stored).toBe(false);
+      expect(h.refusals[0].reason).toBe("missing_scope_study");
+    });
+
+    it("logs the refusal without the entry content", async () => {
+      const h = harness([]);
+      await storeCheckIn(
+        smsEntry({ narrative: "something deeply personal" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      expect(JSON.stringify(h.refusals)).not.toContain("deeply personal");
+    });
+  });
+
+  // ── Boundary: intensity edges ────────────────────────────────────────────
+  it.each([0, 10])(
+    "accepts intensity %i at the boundary",
+    async (intensity) => {
+      const h = harness();
+      const result = await storeCheckIn(
+        smsEntry({ intensity }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      expect(result.stored).toBe(true);
+    },
+  );
+
+  it("rejects an out-of-range intensity rather than clamping it", async () => {
+    const h = harness();
+    const result = await storeCheckIn(
+      smsEntry({ intensity: 11 as never }),
+      h.repo,
+      h.lookup,
+      h.logRefusal,
+    );
+    expect(result.stored).toBe(false);
+    expect(h.refusals[0].reason).toBe("invalid_intensity");
+  });
+
+  // ── Interface / Many: pilot separation ───────────────────────────────────
+  describe("pilot separation", () => {
+    it("excludes pilot rows from analysis queries by construction", async () => {
+      const h = harness();
+      await storeCheckIn(
+        smsEntry({ pilot: true, narrative: "pilot one" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      await storeCheckIn(
+        smsEntry({ narrative: "study one" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      await storeCheckIn(
+        smsEntry({ pilot: true, narrative: "pilot two" }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+
+      const analysable = await analysisEntries(h.repo);
+
+      expect(analysable).toHaveLength(1);
+      expect(analysable[0].narrative).toBe("study one");
+    });
+
+    it("marks pilot on the stored entry immutably at ingest", async () => {
+      const h = harness();
+      await storeCheckIn(
+        smsEntry({ pilot: true }),
+        h.repo,
+        h.lookup,
+        h.logRefusal,
+      );
+      expect(h.stored[0].pilot).toBe(true);
+    });
+  });
+});

--- a/src/lib/checkin/store.ts
+++ b/src/lib/checkin/store.ts
@@ -1,0 +1,81 @@
+import type { ConsentRecord } from "@/lib/consent/types";
+import type { Channel, CheckInEntry, NewCheckIn } from "./types";
+
+/**
+ * Check-in storage with the consent-linkage guard — SLICE-04-01 (issue #44).
+ *
+ * Collection without consent must be impossible, not discouraged, so the
+ * guard lives in the one function every channel must pass through rather
+ * than in each channel's good intentions. Refusals are logged by reason
+ * only — a refused entry's content is exactly the thing we had no right
+ * to keep.
+ */
+
+export type CheckInRepository = {
+  persist(entry: CheckInEntry): Promise<CheckInEntry>;
+  all(): Promise<readonly CheckInEntry[]>;
+};
+
+export type ConsentLookup = (
+  hashedParticipantId: string,
+) => Promise<ConsentRecord | null>;
+
+export type RefusalLog = (reason: string) => void;
+
+export type StoreResult =
+  | { stored: true; entry: CheckInEntry }
+  | { stored: false; reason: string };
+
+const SCOPE_FOR_CHANNEL: Record<Channel, "voice" | null> = {
+  sms: null, // receiving an SMS needs study consent only; sending needs sms scope (#35, #49)
+  voice: "voice",
+};
+
+function invalidIntensity(intensity: NewCheckIn["intensity"]): boolean {
+  if (intensity === "skipped") return false;
+  return !Number.isInteger(intensity) || intensity < 0 || intensity > 10;
+}
+
+export async function storeCheckIn(
+  incoming: NewCheckIn,
+  repo: CheckInRepository,
+  findConsent: ConsentLookup,
+  logRefusal: RefusalLog,
+): Promise<StoreResult> {
+  const refuse = (reason: string): StoreResult => {
+    logRefusal(reason);
+    return { stored: false, reason };
+  };
+
+  const consent = await findConsent(incoming.hashedParticipantId);
+  if (!consent) return refuse("no_consent_record");
+  if (!consent.scopes.study) return refuse("missing_scope_study");
+
+  const channelScope = SCOPE_FOR_CHANNEL[incoming.channel];
+  if (channelScope && !consent.scopes[channelScope]) {
+    return refuse(`missing_scope_${channelScope}`);
+  }
+
+  if (invalidIntensity(incoming.intensity)) return refuse("invalid_intensity");
+
+  const entry: CheckInEntry = Object.freeze({
+    ...incoming,
+    receivedAt: new Date().toISOString(),
+    consentVersion: consent.consentVersion,
+  });
+
+  await repo.persist(entry);
+  return { stored: true, entry };
+}
+
+/**
+ * The only sanctioned read path for analysis. Pilot rows are excluded here,
+ * by construction — an analysis that wants pilot data has to go around this
+ * function, and doing so is the defect the tests exist to catch.
+ */
+export async function analysisEntries(
+  repo: CheckInRepository,
+): Promise<readonly CheckInEntry[]> {
+  const entries = await repo.all();
+  return entries.filter((entry) => !entry.pilot);
+}

--- a/src/lib/checkin/types.ts
+++ b/src/lib/checkin/types.ts
@@ -1,0 +1,53 @@
+/**
+ * The check-in entry — SLICE-04-01 (issue #44).
+ *
+ * Field names mirror the pre-registration's Operational definitions verbatim
+ * (docs/compliance/pre-registration.md). The registration is the spec; the
+ * code follows it, and changes to the instrument go through the registration
+ * first.
+ *
+ * Skips are first-class values, not nulls: the landing page promises any
+ * question can be skipped, and a skipped answer is data (it is counted),
+ * where a null is an accident.
+ */
+
+export type Destination =
+  | "tool"
+  | "other_people"
+  | "myself"
+  | "nowhere"
+  /** Pilot-only fifth option; frozen out or in by SLICE-04-03. */
+  | { other: string }
+  | "skipped";
+
+export type Recency =
+  | "just_now"
+  | "within_hour"
+  | "earlier_today"
+  | "before_today"
+  | "skipped";
+
+export type Intensity = number | "skipped"; // 0–10 integer when present
+
+export type Channel = "sms" | "voice";
+
+/** What a channel hands to storage. */
+export type NewCheckIn = {
+  hashedParticipantId: string;
+  channel: Channel;
+  narrative: string;
+  destination: Destination;
+  intensity: Intensity;
+  recency: Recency;
+  /** Immutable at ingest — pilot data must never mix with study data. */
+  pilot: boolean;
+};
+
+/** What storage persists: the entry plus what only storage may stamp. */
+export type CheckInEntry = Readonly<
+  NewCheckIn & {
+    receivedAt: string;
+    /** The consent text version in force when this entry was accepted. */
+    consentVersion: string;
+  }
+>;

--- a/src/lib/consent/types.ts
+++ b/src/lib/consent/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Consent records — shared between the screener gate (SLICE-00-03, #32) and
+ * check-in storage (SLICE-04-01, #44).
+ *
+ * The three scopes mirror the consent document's three separately-refusable
+ * agreements. Bundled consent is not consent, so they are independent
+ * booleans rather than a single flag.
+ */
+
+export type ConsentScopes = {
+  /** The study itself. Required — without it nothing may be stored. */
+  study: boolean;
+  /** Biometric consent for voice recordings (BIPA-grade, separate). */
+  voice: boolean;
+  /** TCPA consent to receive recurring SMS prompts. */
+  sms: boolean;
+};
+
+export type ConsentRecord = {
+  hashedParticipantId: string;
+  /** Which text they agreed to — the exact version shown, never inferred. */
+  consentVersion: string;
+  scopes: ConsentScopes;
+  agreedAt: string;
+};


### PR DESCRIPTION
Closes #45. Parent EPIC: #43. **Stacked on #50** (uses the entry store and consent guard); retarget when #50 merges.

**Parser:** pure function, order-forgiving, answer-position-aware — a destination word only counts when delimited, so "the app ate my shift, 9, them" reads *them*, and "waited 2 hours" keeps its 2. Never fails; missing pieces are skips.

**Repair:** one gentle prompt, never a loop, and never data loss — the first message's story is held and merged, not discarded. (The first design dropped it; fixed before shipping.)

**Consent on the receive path:** un-consented senders get a neutral reply echoing nothing they wrote. Phones are HMAC-hashed; the raw number is never persisted, and a test asserts the stored record can't contain it.

**The route ships safe-by-default:** consent lookup returns null until enrollment persistence exists, so this endpoint is structurally unable to collect an entry on staging. Pilot mode is an env flag stamping `pilot: true` at ingest.

**Verification:** 44 tests across parser and webhook (27 + 17), red-first where behavior was new; 121 unit tests total; lint/typecheck/build green — the route compiles into the build as `ƒ /api/checkin/sms`.

**Accepted residuals:** repair state and entries are in-memory placeholders behind injected interfaces — persistence is the Firestore adapter's job. Twilio signature validation is not yet implemented and must land before the pilot (noted for #46). Destination vocabulary will grow from pilot free-text.