### PR TITLE
SLICE: EPIC-01 telemetry sink — batched beacon to logging endpoint

### DIFF
--- a/components/TelemetryProvider.tsx
+++ b/components/TelemetryProvider.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { flushTelemetry, installBeaconSink } from "@/lib/telemetrySink";
+
+/**
+ * Installs the beacon sink once per page load and flushes on page-hide, so
+ * exit-adjacent events (the startScreenerClicked that navigates away) are
+ * not lost with the tab. Renders nothing.
+ */
+export function TelemetryProvider() {
+  useEffect(() => {
+    installBeaconSink({});
+
+    const onHide = () => flushTelemetry();
+    document.addEventListener("visibilitychange", onHide);
+    window.addEventListener("pagehide", onHide);
+    return () => {
+      document.removeEventListener("visibilitychange", onHide);
+      window.removeEventListener("pagehide", onHide);
+    };
+  }, []);
+
+  return null;
+}

--- a/docs/compliance/privacy-policy.md
+++ b/docs/compliance/privacy-policy.md
@@ -2,7 +2,7 @@
 
 > **Not approved. Not for publication.** Draft for counsel review — slice #33.
 
-**Last updated:** DRAFT · **Applies to:** thebigmadstudy **[DECIDE — final domain]** and the check-in flows
+**Last updated:** DRAFT · **Applies to:** bigmad.goodcitizens.us and the check-in flows
 
 ---
 

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Interim telemetry endpoint — receives client batches and writes one
+ * structured line per event to the runtime log, where Vercel's log explorer
+ * can filter on `[bm-event]`. Replaced by a vendor adapter when one is
+ * chosen; call sites never change (#12).
+ *
+ * Defensive by shape, not by trust: the client guard already refused PII,
+ * but this endpoint is reachable by anyone, so it enforces size caps and
+ * drops anything that is not a {name, props} pair of primitives.
+ */
+
+const MAX_EVENTS_PER_BATCH = 50;
+const MAX_NAME_LENGTH = 64;
+const MAX_PROP_VALUE_LENGTH = 200;
+
+type Loggable = {
+  name: string;
+  props: Record<string, string | number | boolean>;
+};
+
+function sanitize(candidate: unknown): Loggable | null {
+  if (typeof candidate !== "object" || candidate === null) return null;
+  const { name, props } = candidate as { name?: unknown; props?: unknown };
+  if (
+    typeof name !== "string" ||
+    name.length === 0 ||
+    name.length > MAX_NAME_LENGTH
+  ) {
+    return null;
+  }
+
+  const cleanProps: Loggable["props"] = {};
+  if (typeof props === "object" && props !== null) {
+    for (const [key, value] of Object.entries(props)) {
+      if (key.length > MAX_NAME_LENGTH) continue;
+      if (typeof value === "number" || typeof value === "boolean") {
+        cleanProps[key] = value;
+      } else if (
+        typeof value === "string" &&
+        value.length <= MAX_PROP_VALUE_LENGTH
+      ) {
+        cleanProps[key] = value;
+      }
+    }
+  }
+  return { name, props: cleanProps };
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new NextResponse(null, { status: 204 }) as NextResponse;
+  }
+
+  const events = Array.isArray((body as { events?: unknown[] })?.events)
+    ? (body as { events: unknown[] }).events.slice(0, MAX_EVENTS_PER_BATCH)
+    : [];
+
+  for (const candidate of events) {
+    const event = sanitize(candidate);
+    if (event) {
+      console.log(`[bm-event] ${JSON.stringify(event)}`);
+    }
+  }
+
+  // Always 204: telemetry endpoints have nothing to say to the client, and
+  // an error status would invite retry loops from the page.
+  return new NextResponse(null, { status: 204 }) as NextResponse;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Fraunces, IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 import { HeaderVariantProvider } from "./hooks/HeaderVariantProvider";
+import { TelemetryProvider } from "../../components/TelemetryProvider";
 import { LayoutHeader } from "./layout-header";
 import "./globals.css";
 
@@ -47,6 +48,7 @@ export default function RootLayout({
       <body
         className={`${fraunces.variable} ${plexSans.variable} ${plexMono.variable} bg-paper text-ink`}
       >
+        <TelemetryProvider />
         <HeaderVariantProvider>
           <div className="flex min-h-screen flex-col">
             <LayoutHeader navLinks={navLinks} />

--- a/src/lib/checkin/parseSms.ts
+++ b/src/lib/checkin/parseSms.ts
@@ -34,7 +34,10 @@ const DESTINATION_PATTERNS: [RegExp, ConcreteDestination][] = [
 ];
 
 const RECENCY_PATTERNS: [RegExp, Exclude<Recency, "skipped">][] = [
-  [/(just now|right now|a (minute|moment|second) ago|minutes ago)/i, "just_now"],
+  [
+    /(just now|right now|a (minute|moment|second) ago|minutes ago)/i,
+    "just_now",
+  ],
   [/(within the (last )?hour|an hour ago|past hour)/i, "within_hour"],
   [/(earlier today|this (morning|afternoon)|today)/i, "earlier_today"],
   [/(yesterday|last (night|week)|days? ago|before today)/i, "before_today"],
@@ -47,16 +50,10 @@ const DELIM = "[,.;\\u2014\\u2013-]";
  * delimiter, followed by end-of-message or a delimiter.
  */
 function delimited(inner: string): RegExp {
-  return new RegExp(
-    `(?:^|${DELIM})\\s*(?:${inner})\\s*(?=$|${DELIM})`,
-    "i",
-  );
+  return new RegExp(`(?:^|${DELIM})\\s*(?:${inner})\\s*(?=$|${DELIM})`, "i");
 }
 
-function claim(
-  text: string,
-  inner: string,
-): { found: boolean; rest: string } {
+function claim(text: string, inner: string): { found: boolean; rest: string } {
   const match = text.match(delimited(inner));
   if (!match) return { found: false, rest: text };
   return { found: true, rest: text.replace(match[0], " ") };

--- a/src/lib/checkin/smsWebhook.test.ts
+++ b/src/lib/checkin/smsWebhook.test.ts
@@ -102,7 +102,10 @@ describe("SLICE-04-02 inbound SMS", () => {
 
   it("marks entries as pilot when the flow runs in pilot mode", async () => {
     const pilotDeps = { ...h.deps, pilot: true };
-    await handleInboundSms(fixture("5, them, just now, pilot story"), pilotDeps);
+    await handleInboundSms(
+      fixture("5, them, just now, pilot story"),
+      pilotDeps,
+    );
     expect(h.stored[0].pilot).toBe(true);
   });
 

--- a/src/lib/checkin/smsWebhook.ts
+++ b/src/lib/checkin/smsWebhook.ts
@@ -49,7 +49,8 @@ export async function handleInboundSms(
 ): Promise<string> {
   const hashedParticipantId = deps.hashPhone(message.From);
 
-  const consent: ConsentRecord | null = await deps.findConsent(hashedParticipantId);
+  const consent: ConsentRecord | null =
+    await deps.findConsent(hashedParticipantId);
   if (!consent || !consent.scopes.study) {
     deps.logRefusal("sms_from_unconsented_number");
     return REPLIES.notEnrolled;

--- a/src/lib/telemetrySink.test.ts
+++ b/src/lib/telemetrySink.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushTelemetry, installBeaconSink } from "./telemetrySink";
+import { recordedEvents, resetTelemetry, track } from "./telemetry";
+
+/**
+ * Follow-up to SLICE-04 (#12) — the first real sink.
+ *
+ * Events batch client-side and ship to /api/telemetry. The transport must
+ * never affect the page: a dead endpoint loses events, not visitors. The
+ * PII guard already ran in track(); the sink transports, it does not audit.
+ */
+
+describe("beacon sink", () => {
+  beforeEach(() => {
+    resetTelemetry();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    resetTelemetry();
+  });
+
+  it("batches events and ships them after the flush interval", () => {
+    const sent: unknown[] = [];
+    vi.stubGlobal("fetch", (url: string, init: RequestInit) => {
+      sent.push({ url, body: JSON.parse(String(init.body)) });
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+
+    installBeaconSink({ flushMs: 5000 });
+    track("landingViewed", { device_type: "desktop" });
+    track("startScreenerClicked", { location_on_page: "hero" });
+
+    expect(sent).toHaveLength(0); // nothing ships synchronously
+    vi.advanceTimersByTime(5000);
+
+    expect(sent).toHaveLength(1);
+    const batch = (sent[0] as { body: { events: { name: string }[] } }).body;
+    expect(batch.events.map((e) => e.name)).toEqual([
+      "landingViewed",
+      "startScreenerClicked",
+    ]);
+  });
+
+  it("does not send an empty batch", () => {
+    const sent: unknown[] = [];
+    vi.stubGlobal("fetch", (...args: unknown[]) => {
+      sent.push(args);
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+
+    installBeaconSink({ flushMs: 5000 });
+    vi.advanceTimersByTime(20000);
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it("survives a dead endpoint without breaking the page or the next batch", () => {
+    let calls = 0;
+    vi.stubGlobal("fetch", () => {
+      calls += 1;
+      return Promise.reject(new Error("endpoint down"));
+    });
+
+    installBeaconSink({ flushMs: 1000 });
+    track("landingViewed");
+    expect(() => vi.advanceTimersByTime(1000)).not.toThrow();
+
+    track("aboutPageViewed");
+    vi.advanceTimersByTime(1000);
+    expect(calls).toBe(2); // still trying; page never saw an error
+  });
+
+  it("no longer buffers to the window once installed", () => {
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve(new Response(null, { status: 204 })),
+    );
+    installBeaconSink({ flushMs: 1000 });
+    track("landingViewed");
+
+    // recordedEvents reads the window buffer; a configured sink bypasses it.
+    expect(recordedEvents()).toHaveLength(0);
+  });
+
+  it("flushTelemetry ships immediately for page-hide moments", () => {
+    const sent: unknown[] = [];
+    vi.stubGlobal("fetch", (url: string, init: RequestInit) => {
+      sent.push(JSON.parse(String(init.body)));
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+
+    installBeaconSink({ flushMs: 60000 });
+    track("startScreenerClicked", { location_on_page: "nav" });
+    flushTelemetry();
+
+    expect(sent).toHaveLength(1);
+  });
+});

--- a/src/lib/telemetrySink.ts
+++ b/src/lib/telemetrySink.ts
@@ -1,0 +1,52 @@
+import { configureTelemetry, type TelemetryEvent } from "./telemetry";
+
+/**
+ * The first real sink — batches events to /api/telemetry.
+ *
+ * Interim by design: the endpoint writes structured lines to the runtime
+ * log, which makes EPIC-01's funnel readable in Vercel's log explorer today
+ * without committing to an analytics vendor. Swapping in a vendor later is
+ * a change to the endpoint, not to any call site — that was #12's whole
+ * architecture.
+ *
+ * Transport rules: never synchronous, never throws to the page, never sends
+ * empty batches, and a failed send keeps the page alive. Events in a failed
+ * batch are dropped rather than retried-forever; measurement must never
+ * grow a queue in a visitor's browser.
+ */
+
+let pending: TelemetryEvent[] = [];
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function ship(): void {
+  if (pending.length === 0) return;
+  const events = pending;
+  pending = [];
+
+  try {
+    void fetch("/api/telemetry", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ events }),
+      keepalive: true, // survives page-hide, the sendBeacon use case
+    }).catch(() => {
+      /* a dead endpoint loses events, not visitors */
+    });
+  } catch {
+    /* fetch itself unavailable — same rule */
+  }
+}
+
+export function installBeaconSink({ flushMs = 10_000 } = {}): void {
+  if (timer) clearInterval(timer);
+  pending = [];
+  configureTelemetry((event) => {
+    pending.push(event);
+  });
+  timer = setInterval(ship, flushMs);
+}
+
+/** Immediate ship, for pagehide/visibilitychange moments. */
+export function flushTelemetry(): void {
+  ship();
+}


### PR DESCRIPTION
Follow-up to #12, pre-approved as step (b) of the prelaunch plan. Batched client sink → /api/telemetry → structured runtime-log lines (`[bm-event]`), readable in Vercel's log explorer. Vendor swap later = endpoint change only. Transport never affects the page: async, no throws, no empty batches, dead endpoint loses events not visitors. Endpoint is defensive (caps, shape-check, always 204). 5 sink tests + build green (134 total).