### PR TITLE
CHORE: sink mirrors the window buffer — fixes BM-E2E-02/04

### DIFF
--- a/src/lib/telemetrySink.test.ts
+++ b/src/lib/telemetrySink.test.ts
@@ -73,15 +73,16 @@ describe("beacon sink", () => {
     expect(calls).toBe(2); // still trying; page never saw an error
   });
 
-  it("no longer buffers to the window once installed", () => {
+  it("keeps mirroring to the window buffer once installed", () => {
     vi.stubGlobal("fetch", () =>
       Promise.resolve(new Response(null, { status: 204 })),
     );
     installBeaconSink({ flushMs: 1000 });
     track("landingViewed");
 
-    // recordedEvents reads the window buffer; a configured sink bypasses it.
-    expect(recordedEvents()).toHaveLength(0);
+    // The window buffer is the observability seam the E2E suite reads; the
+    // sink adds transport, it must not remove visibility.
+    expect(recordedEvents()).toHaveLength(1);
   });
 
   it("flushTelemetry ships immediately for page-hide moments", () => {

--- a/src/lib/telemetrySink.ts
+++ b/src/lib/telemetrySink.ts
@@ -42,6 +42,12 @@ export function installBeaconSink({ flushMs = 10_000 } = {}): void {
   pending = [];
   configureTelemetry((event) => {
     pending.push(event);
+    // Mirror to the window buffer: it is the observability seam the E2E
+    // suite and any debugging session read. The sink adds transport; it
+    // must not remove visibility. (Replacing the buffer outright is what
+    // broke BM-E2E-02/04 on the first attempt.)
+    window.__bmTelemetry ??= [];
+    window.__bmTelemetry.push(event);
   });
   timer = setInterval(ship, flushMs);
 }


### PR DESCRIPTION
The sink replaced the window buffer instead of mirroring to it, breaking the observability seam BM-E2E-02/04 read. Caught by the E2E job on #54 — the job added in #11 doing exactly its job. Unit test corrected (it had encoded the wrong behavior); 13 E2E green locally.