### PR TITLE
DOCS: domain is bigmadstudy.com

### DIFF
--- a/docs/compliance/privacy-policy.md
+++ b/docs/compliance/privacy-policy.md
@@ -2,7 +2,7 @@
 
 > **Not approved. Not for publication.** Draft for counsel review — slice #33.
 
-**Last updated:** DRAFT · **Applies to:** bigmad.goodcitizens.us and the check-in flows
+**Last updated:** DRAFT · **Applies to:** bigmadstudy.com and the check-in flows
 
 ---
 


### PR DESCRIPTION
One-line correction: the privacy draft's applies-to line said `bigmad.goodcitizens.us`; the study lives at `bigmadstudy.com` — which #12's job story said all along. Email alias unchanged.