### PR TITLE
DOCS: participant contact is alias@bigmadstudy.com

### DIFF
--- a/docs/compliance/informed-consent.md
+++ b/docs/compliance/informed-consent.md
@@ -8,7 +8,7 @@
 ## Consent to take part in The Big-Mad Behavioral Study
 
 **Run by:** Good Citizens Corporation
-**Contact:** bigmad@goodcitizens.us — monitored by a human
+**Contact:** alias@bigmadstudy.com — monitored by a human
 **Version:** DRAFT-0 · **[DECIDE]** date
 
 Please read this before you answer any questions. You are agreeing to something specific, and you should know exactly what.
@@ -104,13 +104,13 @@ If you participate, you will be able to see your own entries and your own patter
 
 ### Getting your data deleted
 
-Email bigmad@goodcitizens.us and ask. We will delete your entries and your contact information within **[DECIDE]** days and confirm when it is done. You do not need to give a reason.
+Email alias@bigmadstudy.com and ask. We will delete your entries and your contact information within **[DECIDE]** days and confirm when it is done. You do not need to give a reason.
 
 Data already included in published aggregate summaries cannot be pulled back out, because it is no longer separable from anyone else's. Everything else goes.
 
 ### Questions
 
-About the study: bigmad@goodcitizens.us
+About the study: alias@bigmadstudy.com
 About your rights as a participant: **[DECIDE]** — the IRB's contact, once #31 completes. An IRB-reviewed protocol must give participants an independent route to complain.
 
 ---

--- a/docs/compliance/privacy-policy.md
+++ b/docs/compliance/privacy-policy.md
@@ -83,7 +83,7 @@ If data is exposed, we will notify affected participants within **[DECIDE]** and
 
 ## Contact
 
-bigmad@goodcitizens.us — monitored by a human. If you email it, a person reads it.
+alias@bigmadstudy.com — monitored by a human. If you email it, a person reads it.
 
 ---
 

--- a/src/content/consent.ts
+++ b/src/content/consent.ts
@@ -11,7 +11,7 @@
  * text change plus a version bump, not a rebuild.
  */
 
-export const CONSENT_VERSION = "draft-0";
+export const CONSENT_VERSION = "draft-1";
 
 export type ConsentSection = { heading: string; body: string[] };
 
@@ -55,7 +55,7 @@ export const consentSections: ConsentSection[] = [
   {
     heading: "Your data, your call",
     body: [
-      "Email bigmad@goodcitizens.us and ask, and we will delete your entries and contact details, then confirm. You don't need to give a reason.",
+      "Email alias@bigmadstudy.com and ask, and we will delete your entries and contact details, then confirm. You don't need to give a reason.",
     ],
   },
 ];


### PR DESCRIPTION
Moves the participant-facing address onto the study's own domain — 5 places incl. the shipped web consent copy.

Bumps `CONSENT_VERSION` draft-0 → draft-1: changing where a deletion request goes changes what the document means, and the file's own rule is that the version moves with the meaning. Nothing is stranded (no decisions persist yet), and the gate's tests read the constant rather than hardcoding it — so the bump passes clean, proving the versioning seam is live.

**Dependency:** the alias must exist at bigmadstudy.com before publication. 134 tests green.