### PR TITLE
DOCS: contact reverts to placeholder — alias@ wasn't literal

### DIFF
--- a/docs/compliance/informed-consent.md
+++ b/docs/compliance/informed-consent.md
@@ -8,7 +8,7 @@
 ## Consent to take part in The Big-Mad Behavioral Study
 
 **Run by:** Good Citizens Corporation
-**Contact:** alias@bigmadstudy.com — monitored by a human
+**Contact:** [DECIDE]@bigmadstudy.com — monitored by a human
 **Version:** DRAFT-0 · **[DECIDE]** date
 
 Please read this before you answer any questions. You are agreeing to something specific, and you should know exactly what.
@@ -104,13 +104,13 @@ If you participate, you will be able to see your own entries and your own patter
 
 ### Getting your data deleted
 
-Email alias@bigmadstudy.com and ask. We will delete your entries and your contact information within **[DECIDE]** days and confirm when it is done. You do not need to give a reason.
+Email [DECIDE]@bigmadstudy.com and ask. We will delete your entries and your contact information within **[DECIDE]** days and confirm when it is done. You do not need to give a reason.
 
 Data already included in published aggregate summaries cannot be pulled back out, because it is no longer separable from anyone else's. Everything else goes.
 
 ### Questions
 
-About the study: alias@bigmadstudy.com
+About the study: [DECIDE]@bigmadstudy.com
 About your rights as a participant: **[DECIDE]** — the IRB's contact, once #31 completes. An IRB-reviewed protocol must give participants an independent route to complain.
 
 ---

--- a/docs/compliance/privacy-policy.md
+++ b/docs/compliance/privacy-policy.md
@@ -83,7 +83,7 @@ If data is exposed, we will notify affected participants within **[DECIDE]** and
 
 ## Contact
 
-alias@bigmadstudy.com — monitored by a human. If you email it, a person reads it.
+[DECIDE]@bigmadstudy.com — monitored by a human. If you email it, a person reads it.
 
 ---
 

--- a/src/content/consent.ts
+++ b/src/content/consent.ts
@@ -55,7 +55,7 @@ export const consentSections: ConsentSection[] = [
   {
     heading: "Your data, your call",
     body: [
-      "Email alias@bigmadstudy.com and ask, and we will delete your entries and contact details, then confirm. You don't need to give a reason.",
+      "Email [DECIDE]@bigmadstudy.com and ask, and we will delete your entries and contact details, then confirm. You don't need to give a reason.",
     ],
   },
 ];


### PR DESCRIPTION
Reverts my literal reading of a spoken "an alias at bigmadstudy.com". Domain settled, local part open: `[DECIDE]@bigmadstudy.com` in all 5 places. A made-up address in a consent document is worse than a visible blank. CONSENT_VERSION stays draft-1 — versions don't go backwards; the real address will be draft-2.