### PR TITLE
DOCS: semantic contact aliases for bigmadstudy.com

### DIFF
--- a/docs/compliance/contact-addresses.md
+++ b/docs/compliance/contact-addresses.md
@@ -1,0 +1,39 @@
+# Contact addresses
+
+The study's addresses, one per **audience and obligation** — not one per department. Each exists because some document promises someone a way to reach us, and the promise differs in kind.
+
+**Status:** the aliases below must be created at `bigmadstudy.com` before any document referencing them is published. A consent form pointing at a bouncing address is worse than one with a blank in it.
+
+## The set
+
+| Address | For | Referenced by | Response commitment |
+| --- | --- | --- | --- |
+| `study@bigmadstudy.com` | Participant questions about the study — what it is, how to take part, what happens next. The default human channel. | Consent ("About the study"), landing page | **[DECIDE]** — recommend 2 business days, stated publicly |
+| `privacy@bigmadstudy.com` | Data questions, deletion requests, "what do you have on me". | Consent (deletion path), privacy policy, screener confirmation | Bounded by the published deletion window — **[DECIDE]** days |
+| `methods@bigmadstudy.com` | Methodologists, peer reviewers, replication requests, the methods brief. | Methods brief, pre-registration, `/methods` | Best effort; no participant relies on it |
+| `press@bigmadstudy.com` | Media and inbound from recruitment posts. | Public site footer (when added) | Best effort |
+| `security@bigmadstudy.com` | Vulnerability disclosure. Cheap to run, and the alternative is a researcher with no route reporting it publicly. | `/.well-known/security.txt` (when added) | Best effort, acknowledged |
+| `noreply@bigmadstudy.com` | Outbound transactional sending identity. Never monitored, and says so in every message it sends. | Prompt/confirmation email, if email is ever used | None — must state where to reply instead |
+
+## Why these are separate
+
+**`privacy@` is not a courtesy split.** Deletion and access requests carry a published response window and are the channel a regulator or IRB would ask about. Keeping them out of the general-questions inbox is what makes "we will delete within N days" auditable rather than aspirational — and it means a deletion request cannot be lost behind twenty "when does this start?" emails.
+
+**`study@` is the one that must be genuinely monitored.** The distress protocol (#37) directs participants in crisis to 988 rather than to us, so no `urgent@` exists by design — but a participant who discloses something serious will often reply to whatever address they already have. That makes `study@` a place where a hard message can arrive with no warning, and it needs a named reader with a named backup.
+
+**`methods@` keeps peer correspondence off a personal address.** The methods brief currently goes out from `bob@goodcitizens.us`; a study making public claims about transparency should survive its author changing jobs.
+
+**`noreply@` exists to be honest.** If outbound mail is ever sent, its From address should not imply a conversation that nobody is reading.
+
+## Not created, deliberately
+
+- `urgent@` / `crisis@` — would imply a monitored emergency channel this study cannot staff. The protocol routes to 988 and 911 instead, and says so in consent.
+- `support@` — duplicates `study@` for a study with no product to support.
+- `info@` / `hello@` / `contact@` — generic catch-alls that collect spam and tell a participant nothing about who reads them.
+- `irb@` — the IRB's own contact goes in the consent document (#31); it is theirs, not ours, and forwarding it through us would defeat the independence it exists to provide.
+
+## Open
+
+- **[DECIDE]** Who monitors `study@` and `privacy@`, with a named backup. Likely the same two humans as the check-in reviewers (#37) and coders (#48).
+- **[DECIDE]** Published response windows for `study@` and `privacy@`. Do not publish one you cannot keep on a bad week.
+- **[DECIDE]** Whether all six forward to one inbox initially. Forwarding is fine and normal at this size — the semantic separation is for the reader and the auditor, and it survives being backed by a single mailbox. What must not happen is publishing an address that reaches nobody.

--- a/docs/compliance/informed-consent.md
+++ b/docs/compliance/informed-consent.md
@@ -8,7 +8,7 @@
 ## Consent to take part in The Big-Mad Behavioral Study
 
 **Run by:** Good Citizens Corporation
-**Contact:** [DECIDE]@bigmadstudy.com — monitored by a human
+**Contact:** study@bigmadstudy.com — monitored by a human
 **Version:** DRAFT-0 · **[DECIDE]** date
 
 Please read this before you answer any questions. You are agreeing to something specific, and you should know exactly what.
@@ -104,13 +104,13 @@ If you participate, you will be able to see your own entries and your own patter
 
 ### Getting your data deleted
 
-Email [DECIDE]@bigmadstudy.com and ask. We will delete your entries and your contact information within **[DECIDE]** days and confirm when it is done. You do not need to give a reason.
+Email privacy@bigmadstudy.com and ask. We will delete your entries and your contact information within **[DECIDE]** days and confirm when it is done. You do not need to give a reason.
 
 Data already included in published aggregate summaries cannot be pulled back out, because it is no longer separable from anyone else's. Everything else goes.
 
 ### Questions
 
-About the study: [DECIDE]@bigmadstudy.com
+About the study: study@bigmadstudy.com
 About your rights as a participant: **[DECIDE]** — the IRB's contact, once #31 completes. An IRB-reviewed protocol must give participants an independent route to complain.
 
 ---

--- a/docs/compliance/methods-brief.md
+++ b/docs/compliance/methods-brief.md
@@ -81,4 +81,4 @@ Ethics and consent (an independent IRB submission is in preparation, with a sepa
 - Registered-in-advance limitations: opt-in self-selection (now the central sampling property — the study is unpaid), public framing primes attention, recall favors extremes, associations not causation, self-report throughout
 - Consent, privacy, retention, and distress-protocol drafts: `docs/compliance/`
 
-Contact: **Bob Duebelbeis** · bob@goodcitizens.us
+Contact: **Bob Duebelbeis**, Good Citizens Corporation · methods@bigmadstudy.com

--- a/docs/compliance/privacy-policy.md
+++ b/docs/compliance/privacy-policy.md
@@ -83,7 +83,9 @@ If data is exposed, we will notify affected participants within **[DECIDE]** and
 
 ## Contact
 
-[DECIDE]@bigmadstudy.com — monitored by a human. If you email it, a person reads it.
+privacy@bigmadstudy.com — monitored by a human. If you email it, a person reads it.
+
+General questions about taking part go to study@bigmadstudy.com; this address is for your data specifically, so requests about it are not lost behind them.
 
 ---
 

--- a/src/content/consent.ts
+++ b/src/content/consent.ts
@@ -11,7 +11,7 @@
  * text change plus a version bump, not a rebuild.
  */
 
-export const CONSENT_VERSION = "draft-1";
+export const CONSENT_VERSION = "draft-2";
 
 export type ConsentSection = { heading: string; body: string[] };
 
@@ -55,7 +55,8 @@ export const consentSections: ConsentSection[] = [
   {
     heading: "Your data, your call",
     body: [
-      "Email [DECIDE]@bigmadstudy.com and ask, and we will delete your entries and contact details, then confirm. You don't need to give a reason.",
+      "Email privacy@bigmadstudy.com and ask, and we will delete your entries and contact details, then confirm. You don't need to give a reason.",
+      "Anything else — what this is, how it works, whether it's for you — goes to study@bigmadstudy.com, where a person reads it.",
     ],
   },
 ];


### PR DESCRIPTION
Six addresses, one per audience-and-obligation: `study@` `privacy@` `methods@` `press@` `security@` `noreply@` — each defined in `docs/compliance/contact-addresses.md` and wired to its actual use in the consent draft, privacy policy, methods brief, and shipped consent copy. CONSENT_VERSION → draft-2.

`privacy@` is split from `study@` because deletion requests carry a published window and are what an IRB or regulator asks about — they must not queue behind general questions. No `urgent@`/`crisis@` by design: the distress protocol routes to 988, and an emergency alias would imply staffing this study doesn't have.

**Action for you:** create the six at bigmadstudy.com before any of these documents publish. Forwarding all six to one inbox is fine at this size — the separation is for the reader and the auditor. 134 tests green.